### PR TITLE
media-keys: fix the "calculator key"

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -1050,7 +1050,13 @@ do_action (MsdMediaKeysManager *manager,
                 do_media_action (manager);
                 break;
         case CALCULATOR_KEY:
-                execute (manager, "gcalctool", FALSE, FALSE);
+                if ((cmd = g_find_program_in_path ("mate-calc"))) {
+                        execute (manager, "mate-calc", FALSE, FALSE);
+                } else {
+                        execute (manager, "gcalctool", FALSE, FALSE);
+                }
+
+                g_free (cmd);
                 break;
         case PLAY_KEY:
                 return do_multimedia_player_action (manager, "Play");


### PR DESCRIPTION
try to find mate-calc, fall back to gcalctool if it is not found.

Signed-off-by: Stefan Tauner stefan.tauner@student.tuwien.ac.at
