### PR TITLE
incorrect-fsf-address

### DIFF
--- a/mate-settings-daemon/mate-settings-plugin.h
+++ b/mate-settings-daemon/mate-settings-plugin.h
@@ -15,8 +15,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
  */
 
 #ifndef __MATE_SETTINGS_PLUGIN_H__


### PR DESCRIPTION
before

[rave@mother ~]$ rpmlint /var/lib/mock/fedora-16-x86_64/mate-settings-daemon-devel-1.4.0-5.fc16.x86_64.rpm 
mate-settings-daemon-devel.x86_64: W: no-documentation
mate-settings-daemon-devel.x86_64: E: incorrect-fsf-address /usr/include/mate-settings-daemon/mate-settings-plugin.h
1 packages and 0 specfiles checked; 1 errors, 1 warnings.

after

[rave@mother ~]$ rpmlint /home/rave/rpmbuild/RPMS/x86_64/mate-settings-daemon-devel-1.4.0-5.fc16.x86_64.rpm
mate-settings-daemon-devel.x86_64: W: no-documentation
1 packages and 0 specfiles checked; 0 errors, 1 warnings.
