### PR TITLE
Restore volume-step preference instead of hardcoding it

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -657,7 +657,10 @@ do_sound_action (MsdMediaKeysManager *manager,
                 return;
 #endif
 
-	vol_step = VOLUME_STEP;
+        vol_step = g_settings_get_int (manager->priv->settings, "volume-step");
+
+        if (vol_step <= 0 || vol_step > 100)
+                vol_step = VOLUME_STEP;
 
 #ifdef HAVE_PULSE
         norm_vol_step = PA_VOLUME_NORM * vol_step / 100;


### PR DESCRIPTION
This restores the reading of org.mate.SettingsDaemon.plugins.media-keys.volume-step for the volume buttons. This was removed in https://github.com/mate-desktop/mate-settings-daemon/commit/5129b9008a6700294bcd8d8f0fcaee4bef2932fc but the setting key was already in org.mate.SettingsDaemon.plugins.media-keys, not org.mate.SettingsDaemon like http://git.gnome.org/browse/gnome-settings-daemon/commit/?id=1a9eea8224d41643a8a7a05d799198058e36e1a8. 

Since this key is already in the right location (the plugin's settings, not the main settings daemon settings), there does not seem to be any reason to remove this preference.
