### PR TITLE
Fix gsettings schema paths

### DIFF
--- a/data/org.mate.applications-at.gschema.xml.in
+++ b/data/org.mate.applications-at.gschema.xml.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.applications-at" path="/desktop/mate/applications/at/">
+  <schema id="org.mate.applications-at" path="/org/mate/desktop/applications/at/">
     <key name="screen-keyboard-enabled" type="b">
       <default>false</default>
       <_summary>On-screen keyboard</_summary>

--- a/data/org.mate.font-rendering.gschema.xml.in
+++ b/data/org.mate.font-rendering.gschema.xml.in
@@ -16,7 +16,7 @@
     <value nick="vrgb" value="2"/>
     <value nick="vbgr" value="3"/>
   </enum>
-  <schema id="org.mate.font-rendering" path="/desktop/mate/font-rendering/">
+  <schema id="org.mate.font-rendering" path="/org/mate/desktop/font-rendering/">
     <key name="dpi" type="d">
       <default>0.0</default>
       <_summary>DPI</_summary>

--- a/data/org.mate.keybindings.gschema.xml.in
+++ b/data/org.mate.keybindings.gschema.xml.in
@@ -1,5 +1,5 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.keybindings" path="/desktop/mate/keybindings/">
+  <schema id="org.mate.keybindings" path="/org/mate/desktop/keybindings/">
     <key name="allowed-keys" type="as">
       <default>[]</default>
       <_summary>Allowed keys</_summary>
@@ -9,7 +9,7 @@
     <child name="screenreader" schema="org.mate.keybindings.screenreader"/>
     <child name="onscreenkeyboard" schema="org.mate.keybindings.onscreenkeyboard"/>
   </schema>
-  <schema id="org.mate.keybindings.magnifier" path="/desktop/mate/keybindings/magnifier/">
+  <schema id="org.mate.keybindings.magnifier" path="/org/mate/desktop/keybindings/magnifier/">
     <key name="binding" type="s">
       <default>''</default>
       <summary>Toggle magnifier</summary>
@@ -26,7 +26,7 @@
       <description>Command used to turn the magnifier on or off.</description>
     </key>
   </schema>
-  <schema id="org.mate.keybindings.screenreader" path="/desktop/mate/keybindings/screenreader/">
+  <schema id="org.mate.keybindings.screenreader" path="/org/mate/desktop/keybindings/screenreader/">
     <key name="binding" type="s">
       <default>''</default>
       <summary>Toggle screen reader</summary>
@@ -43,7 +43,7 @@
       <description>Command used to turn the screen reader on or off.</description>
     </key>
   </schema>
-  <schema id="org.mate.keybindings.onscreenkeyboard" path="/desktop/mate/keybindings/onscreenkeyboard/">
+  <schema id="org.mate.keybindings.onscreenkeyboard" path="/org/mate/desktop/keybindings/onscreenkeyboard/">
     <key name="name" type="s">
       <default context="name" l10n="messages">'Toggle on-screen keyboard'</default>
       <summary>The name of the keyboard shortcut to toggle the on-screen keyboard</summary>

--- a/data/org.mate.peripherals-smartcard.gschema.xml.in
+++ b/data/org.mate.peripherals-smartcard.gschema.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <schemalist>
-  <schema id="org.mate.peripherals-smartcard" path="/desktop/mate/peripherals/smartcard/">
+  <schema id="org.mate.peripherals-smartcard" path="/org/mate/desktop/peripherals/smartcard/">
     <key name="removal-action" type="s">
       <default>'none'</default>
       <summary>Smartcard removal action</summary>

--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -1,5 +1,5 @@
 <schemalist>
-  <schema id="org.mate.peripherals-touchpad" path="/desktop/mate/peripherals/touchpad/">
+  <schema id="org.mate.peripherals-touchpad" path="/org/mate/desktop/peripherals/touchpad/">
     <key name="disable-while-typing" type="b">
       <default>false</default>
       <summary>Disable touchpad while typing</summary>

--- a/plugins/xrdb/msd-xrdb-manager.c
+++ b/plugins/xrdb/msd-xrdb-manager.c
@@ -48,7 +48,6 @@
 #define USER_X_RESOURCES ".Xresources"
 #define USER_X_DEFAULTS  ".Xdefaults"
 
-#define GTK_THEME_KEY "/desktop/mate/interface/gtk_theme"
 
 struct MsdXrdbManagerPrivate {
 	GtkWidget* widget;


### PR DESCRIPTION
The schemas were still using /desktop/mate/... instead of /org/mate/desktop/...
This fixes the paths to avoid the deprecated /desktop/ path.
