### PR TITLE
Custom PulseAudio max volume

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in.in
+++ b/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in.in
@@ -15,6 +15,11 @@
       <_summary>Volume step</_summary>
       <_description>Volume step as percentage of volume.</_description>
     </key>
+    <key name="volume-max" type="i">
+      <default>65536</default>
+      <_summary>Volume max</_summary>
+      <_description>Upper bound for volume on a pulseaudio system.</_description>
+    </key>
     <key name="touchpad" type="s">
       <default>'XF86TouchpadToggle'</default>
       <_summary>Toggle touchpad</_summary>

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -65,8 +65,6 @@
 #define TOUCHPAD_SCHEMA "org.mate.peripherals-touchpad"
 #define TOUCHPAD_ENABLED_KEY "touchpad-enabled"
 
-#define MAX_VOLUME 65536.0
-
 #define MSD_MEDIA_KEYS_MANAGER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MEDIA_KEYS_MANAGER, MsdMediaKeysManagerPrivate))
 
 typedef struct {
@@ -612,13 +610,21 @@ do_touchpad_action (MsdMediaKeysManager *manager)
 }
 
 #ifdef HAVE_PULSE
+static double
+get_max_volume (MsdMediaKeysManager *manager)
+{
+    return g_settings_get_int (manager->priv->settings, "volume-max");
+}
+
 static void
 update_dialog (MsdMediaKeysManager *manager,
                guint vol,
                gboolean muted,
                gboolean sound_changed)
 {
-        vol = (int) (100 * (double) vol / MAX_VOLUME);
+        int maxvol = get_max_volume(manager);
+
+        vol = (int) (100 * (double) vol / maxvol);
         vol = CLAMP (vol, 0, 100);
 
         dialog_init (manager);
@@ -732,9 +738,11 @@ do_sound_action (MsdMediaKeysManager *manager,
 #endif
                 } else {
 #ifdef HAVE_PULSE
-                        if (vol < MAX_VOLUME) {
-                                if (vol + norm_vol_step >= MAX_VOLUME) {
-                                        vol = MAX_VOLUME;
+                        int maxvol = get_max_volume(manager);
+
+                        if (vol < maxvol) {
+                                if (vol + norm_vol_step >= maxvol) {
+                                        vol = maxvol;
                                 } else {
                                         vol = vol + norm_vol_step;
                                 }

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -65,7 +65,6 @@
 #define TOUCHPAD_SCHEMA "org.mate.peripherals-touchpad"
 #define TOUCHPAD_ENABLED_KEY "touchpad-enabled"
 
-#define VOLUME_STEP 6           /* percents for one volume button press */
 #define MAX_VOLUME 65536.0
 
 #define MSD_MEDIA_KEYS_MANAGER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MEDIA_KEYS_MANAGER, MsdMediaKeysManagerPrivate))
@@ -658,9 +657,6 @@ do_sound_action (MsdMediaKeysManager *manager,
 #endif
 
         vol_step = g_settings_get_int (manager->priv->settings, "volume-step");
-
-        if (vol_step <= 0 || vol_step > 100)
-                vol_step = VOLUME_STEP;
 
 #ifdef HAVE_PULSE
         norm_vol_step = PA_VOLUME_NORM * vol_step / 100;

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -619,7 +619,7 @@ update_dialog (MsdMediaKeysManager *manager,
                gboolean muted,
                gboolean sound_changed)
 {
-        vol = (int) (100 * (double) vol / PA_VOLUME_NORM);
+        vol = (int) (100 * (double) vol / MAX_VOLUME);
         vol = CLAMP (vol, 0, 100);
 
         dialog_init (manager);


### PR DESCRIPTION
Allows the user using PulseAudio to specify a custom max volume value through the gsettings schema interface instead of the hard-coded MAX_VOLUME specified in the source code.

Commits a9bfbd6 and b4044c3 only occur under pulse, while c4e2a39 affects both pulse and gstreamer.
Tested with both pulse and gstreamer backends.