### PR TITLE
Update msd-mouse-manager.c

### DIFF
--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -677,8 +677,8 @@ set_tap_to_click (gboolean state, gboolean left_handed)
                         if (rc == Success && type == XA_INTEGER && format == 8 && nitems >= 7)
                         {
                                 /* Set RLM mapping for 1/2/3 fingers*/
-                                data[4] = (state) ? ((left_handed) ? 3 : 1) : 0;
-                                data[5] = (state) ? ((left_handed) ? 1 : 3) : 0;
+                                data[4] = (state) ? 1 : 0;
+                                data[5] = (state) ? 3 : 0;
                                 data[6] = (state) ? 2 : 0;
                                 XChangeDeviceProperty (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), device, prop, XA_INTEGER, 8,
                                                         PropModeReplace, data, nitems);
@@ -896,7 +896,7 @@ set_locate_pointer (MsdMouseManager *manager,
                 kill (manager->priv->locate_pointer_pid, SIGHUP);
                 g_spawn_close_pid (manager->priv->locate_pointer_pid);
                 manager->priv->locate_pointer_spawned = FALSE;
-        }
+        }
 }
 
 static void


### PR DESCRIPTION
Changed the mapping of one-finger and two-finger taps. Default settings would map single-tap to right-click and two-finger tap to left-click if left-hand mode was enabled from the settings menu.
