### PR TITLE
xsettings plugin: first connect to settings, then read them.

### DIFF
--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -683,6 +683,13 @@ mate_xsettings_manager_start (MateXSettingsManager *manager,
         g_hash_table_insert (manager->priv->gsettings,
                              SOUND_SCHEMA, g_settings_new (SOUND_SCHEMA));
 
+        list = g_hash_table_get_values (manager->priv->gsettings);
+        for (l = list; l != NULL; l = l->next) {
+                g_signal_connect_object (G_OBJECT (l->data), "changed",
+                			 G_CALLBACK (xsettings_callback), manager, 0);
+        }
+        g_list_free (list);
+
         for (i = 0; i < G_N_ELEMENTS (translations); i++) {
                 GVariant  *val;
                 GSettings *gsettings;
@@ -700,13 +707,6 @@ mate_xsettings_manager_start (MateXSettingsManager *manager,
                 process_value (manager, &translations[i], val);
                 g_variant_unref (val);
         }
-
-        list = g_hash_table_get_values (manager->priv->gsettings);
-        for (l = list; l != NULL; l = l->next) {
-                g_signal_connect_object (G_OBJECT (l->data), "changed",
-                			 G_CALLBACK (xsettings_callback), manager, 0);
-        }
-        g_list_free (list);
 
         manager->priv->gsettings_font = g_settings_new (FONT_RENDER_SCHEMA);
         g_signal_connect (manager->priv->gsettings_font, "changed", G_CALLBACK (xft_callback), manager);


### PR DESCRIPTION
fixes the issue with GLib >= 2.43,
https://git.gnome.org/browse/glib/commit/?id=8ff5668a458344da22d30491e3ce726d861b3619