### PR TITLE
GTK3: use gdk_error_trap_pop_ignored() when appropriate

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -185,7 +185,11 @@ get_xkb_desc_rec (MsdA11yKeyboardManager *manager)
                 desc->ctrls = NULL;
                 status = XkbGetControls (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), XkbAllControlsMask, desc);
         }
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         g_return_val_if_fail (desc != NULL, NULL);
         g_return_val_if_fail (desc->ctrls != NULL, NULL);
@@ -392,7 +396,11 @@ set_server_from_settings (MsdA11yKeyboardManager *manager)
         XkbFreeKeyboard (desc, XkbAllComponentsMask, True);
 
         XSync (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), FALSE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         mate_settings_profile_end (NULL);
 }
@@ -1073,7 +1081,11 @@ restore_server_xkb_config (MsdA11yKeyboardManager *manager)
                          XkbAllComponentsMask, True);
 
         XSync (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), FALSE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         manager->priv->original_xkb_desc = NULL;
 }

--- a/plugins/clipboard/msd-clipboard-manager.c
+++ b/plugins/clipboard/msd-clipboard-manager.c
@@ -151,7 +151,11 @@ send_selection_notify (MsdClipboardManager *manager,
                     (XEvent *)&notify);
         XSync (manager->priv->display, False);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 }
 
 static void
@@ -178,7 +182,11 @@ finish_selection_request (MsdClipboardManager *manager,
                     False, NoEventMask, (XEvent *) &notify);
         XSync (manager->priv->display, False);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 }
 
 static int
@@ -554,7 +562,11 @@ convert_clipboard_target (IncrConversion      *rdata,
 
                         XSync (manager->priv->display, False);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+                        gdk_error_trap_pop_ignored ();
+#else
                         gdk_error_trap_pop ();
+#endif
                 }
         }
 }

--- a/plugins/common/msd-input-helper.c
+++ b/plugins/common/msd-input-helper.c
@@ -22,6 +22,7 @@
 
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
+#include <gtk/gtk.h>
 
 #include <sys/types.h>
 #include <X11/Xatom.h>
@@ -65,11 +66,19 @@ device_is_touchpad (XDeviceInfo deviceinfo)
         if ((XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), device, prop, 0, 1, False,
                                 XA_INTEGER, &realtype, &realformat, &nitems,
                                 &bytes_after, &data) == Success) && (realtype != None)) {
+#if GTK_CHECK_VERSION (3, 0, 0)
+                gdk_error_trap_pop_ignored ();
+#else
                 gdk_error_trap_pop ();
+#endif
                 XFree (data);
                 return device;
         }
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         XCloseDevice (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), device);
         return NULL;

--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -330,7 +330,11 @@ binding_unregister_keys (MsdKeybindingsManager *manager)
 
         if (need_flush)
                 gdk_flush ();
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 }
 
 static void

--- a/plugins/keyboard/msd-keyboard-manager.c
+++ b/plugins/keyboard/msd-keyboard-manager.c
@@ -312,7 +312,11 @@ apply_settings (GSettings          *settings,
 #endif /* HAVE_X11_EXTENSIONS_XKB_H */
 
         XSync (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()), FALSE);
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 }
 
 void

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -1200,7 +1200,11 @@ msd_media_keys_manager_stop (MsdMediaKeysManager *manager)
 
         if (need_flush)
                 gdk_flush ();
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         g_slist_free (priv->screens);
         priv->screens = NULL;

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -302,7 +302,11 @@ touchpad_has_single_button (XDevice *device)
         if (rc == Success)
                 XFree (data);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gdk_error_trap_pop_ignored ();
+#else
         gdk_error_trap_pop ();
+#endif
 
         return is_single_button;
 }
@@ -568,7 +572,11 @@ set_middle_button (MsdMouseManager *manager,
                         XChangeDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                                device, prop, type, format, PropModeReplace, data, nitems);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+                        gdk_error_trap_pop_ignored ();
+#else
                         gdk_error_trap_pop ();
+#endif
                 }
 
                 XFree (data);

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -2378,7 +2378,11 @@ msd_xrandr_manager_start (MsdXrandrManager *manager,
                           True, GrabModeAsync, GrabModeAsync);
 
                 gdk_flush ();
+#if GTK_CHECK_VERSION (3, 0, 0)
+                gdk_error_trap_pop_ignored ();
+#else
                 gdk_error_trap_pop ();
+#endif
         }
 
         if (manager->priv->rotate_windows_keycode) {
@@ -2390,7 +2394,11 @@ msd_xrandr_manager_start (MsdXrandrManager *manager,
                           True, GrabModeAsync, GrabModeAsync);
 
                 gdk_flush ();
+#if GTK_CHECK_VERSION (3, 0, 0)
+                gdk_error_trap_pop_ignored ();
+#else
                 gdk_error_trap_pop ();
+#endif
         }
 
         show_timestamps_dialog (manager, "Startup");
@@ -2429,7 +2437,11 @@ msd_xrandr_manager_stop (MsdXrandrManager *manager)
                             manager->priv->switch_video_mode_keycode, AnyModifier,
                             gdk_x11_get_default_root_xwindow());
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+                gdk_error_trap_pop_ignored ();
+#else
                 gdk_error_trap_pop ();
+#endif
         }
 
         if (manager->priv->rotate_windows_keycode) {
@@ -2439,7 +2451,11 @@ msd_xrandr_manager_stop (MsdXrandrManager *manager)
                             manager->priv->rotate_windows_keycode, AnyModifier,
                             gdk_x11_get_default_root_xwindow());
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+                gdk_error_trap_pop_ignored ();
+#else
                 gdk_error_trap_pop ();
+#endif
         }
 
         gdk_window_remove_filter (gdk_get_default_root_window (),


### PR DESCRIPTION
taken from:
https://git.gnome.org/browse/gnome-settings-daemon/commit/?id=544526d