### PR TITLE
xrandr: Don't remove slider background

### DIFF
--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -2129,7 +2129,6 @@ status_icon_popup_menu (MsdXrandrManager *manager, guint button, guint32 timesta
         /*Set up the gtk theme class from mate-panel*/
         GtkStyleContext *context;
         context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-        gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
         gtk_style_context_add_class(context,"gnome-panel-menu-bar");
         gtk_style_context_add_class(context,"mate-panel-menu-bar");
 #endif


### PR DESCRIPTION
This fixes the invisible text for GTK+ 3 themes which don't support mate-panel explicitly. Themes could still overwrite the background if they want in the usual way.