### PR TITLE
xrandr: Install icon into hicolor directory

### DIFF
--- a/plugins/xrandr/Makefile.am
+++ b/plugins/xrandr/Makefile.am
@@ -1,4 +1,4 @@
-icondir = $(datadir)/icons/mate
+icondir = $(datadir)/icons/hicolor
 context = apps
 
 BUILT_SOURCES =				\


### PR DESCRIPTION
msd-xrandr is a custom icon, and it needs to be installed into the standard location, otherwise it's missing from icon themes other than mate.