### PR TITLE
remove extra glib version check from build conf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,13 +48,6 @@ AS_AC_EXPAND(LIBEXECDIR, "$libexecdir")
 MSD_INTLTOOL_PLUGIN_RULE='%.mate-settings-plugin:   %.mate-settings-plugin.in   $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*.po) ; LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< [$]@'
 AC_SUBST([MSD_INTLTOOL_PLUGIN_RULE])
 
-
-# GLib min/max required versions
-AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_36],
-	[Warn on use of APIs added after GLib 2.36])
-AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_36],
-	[Warn on use of APIs deprecated before GLib 2.36])
-
  dnl Unconditionally use this dir to avoid a circular dep with matecc
 MATE_KEYBINDINGS_KEYSDIR="${datadir}/mate-control-center/keybindings"
 AC_SUBST(MATE_KEYBINDINGS_KEYSDIR)


### PR DESCRIPTION
configure.ac runs the same glib version check twice. This commit removes the second code block.
