### PR TITLE
media-keys: add setting to disable osd display

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
+++ b/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
@@ -5,6 +5,11 @@
       <summary>Activation of this plugin</summary>
       <description>Whether this plugin would be activated by mate-settings-daemon or not</description>
     </key>
+    <key name="show-dialog" type="b">
+      <default>true</default>
+      <summary>Show notification dialog</summary>
+      <description>Whether a notification dialog is shown by this plugin</description>
+    </key>
     <key name="priority" type="i">
       <default>98</default>
       <summary>Priority to use for this plugin</summary>

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -573,11 +573,13 @@ do_eject_action (MsdMediaKeysManager *manager)
         }
 
         /* Show the dialogue */
-        dialog_init (manager);
-        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 "media-eject",
-                                                 FALSE);
-        dialog_show (manager);
+        if (g_settings_get_boolean (manager->priv->settings, "show-dialog")) {
+                dialog_init (manager);
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                         "media-eject",
+                                                         FALSE);
+                dialog_show (manager);
+        }
 
         /* Clean up the drive selection and exit if no suitable
          * drives are found */
@@ -603,17 +605,22 @@ do_touchpad_action (MsdMediaKeysManager *manager)
         gboolean state = g_settings_get_boolean (settings, TOUCHPAD_ENABLED_KEY);
 
         if (touchpad_is_present () == FALSE) {
-                dialog_init (manager);
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                         "touchpad-disabled", FALSE);
+                if (g_settings_get_boolean (manager->priv->settings, "show-dialog")) {
+                        dialog_init (manager);
+                        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                                 "touchpad-disabled", FALSE);
+                        dialog_show (manager);
+                }
                 return;
         }
-
-        dialog_init (manager);
-        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 (!state) ? "touchpad-enabled" : "touchpad-disabled",
-                                                 FALSE);
-        dialog_show (manager);
+        
+        if (g_settings_get_boolean (manager->priv->settings, "show-dialog")) {
+                dialog_init (manager);
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                         (!state) ? "touchpad-enabled" : "touchpad-disabled",
+                                                         FALSE);
+                dialog_show (manager);
+        }
 
         g_settings_set_boolean (settings, TOUCHPAD_ENABLED_KEY, !state);
         g_object_unref (settings);
@@ -718,11 +725,13 @@ do_sound_action (MsdMediaKeysManager *manager, int type)
                 else
                         volume = volume_last;
         }
-
-        update_dialog (manager,
-                       CLAMP (100 * volume / (volume_max - volume_min), 0, 100),
-                       muted,
-                       sound_changed);
+        
+        if (g_settings_get_boolean (manager->priv->settings, "show-dialog")) {
+                update_dialog (manager,
+                               CLAMP (100 * volume / (volume_max - volume_min), 0, 100),
+                               muted,
+                               sound_changed);
+        }
 }
 
 static void

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2001-2003 Bastien Nocera <hadess@hadess.net>
  * Copyright (C) 2006-2007 William Jon McCann <mccann@jhu.edu>
  * Copyright (C) 2014 Michal Ratajsky <michal.ratajsky@gmail.com>
+ * Copyright (C) 2015 Friedrich Herbst <frimam@web.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This adds a setting to turn of the osd display for the media-keys plugin of mate-settings-daemon. It fixes #13 and point six on the roadmap.