### PR TITLE
Add option to enable/disable the OSD for media-keys

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
+++ b/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
@@ -5,6 +5,11 @@
       <summary>Activation of this plugin</summary>
       <description>Whether this plugin would be activated by mate-settings-daemon or not</description>
     </key>
+    <key name="show-dialog" type="b">
+      <default>true</default>
+      <summary>Show notification dialog</summary>
+      <description>Whether a dialog is shown to notify about changes</description>
+    </key>
     <key name="priority" type="i">
       <default>98</default>
       <summary>Priority to use for this plugin</summary>

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -410,6 +410,10 @@ dialog_show (MsdMediaKeysManager *manager)
         gtk_window_set_screen (GTK_WINDOW (manager->priv->dialog),
                                manager->priv->current_screen);
 
+        /* Return if show-dialog is disabled */
+        if (!g_settings_get_boolean (manager->priv->settings, "show-dialog"))
+                return;
+
         /*
          * get the window size
          * if the window hasn't been mapped, it doesn't necessarily


### PR DESCRIPTION
This adds an option to the mate-settings-daemon media-keys plugin which enables or disables the OSD window. This fixes #13 and maybe point six on the roadmap.