### PR TITLE
gtk3: css themes for MsdOsdWindow

### DIFF
--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -637,6 +637,11 @@ msd_osd_window_class_init (MsdOsdWindowClass *klass)
                                                         G_TYPE_NONE, 1,
                                                         G_TYPE_POINTER);
 
+#if GTK_CHECK_VERSION (3, 20, 0)
+        GtkWidgetClass *widget_class  = GTK_WIDGET_CLASS (class);
+        gtk_widget_class_set_css_name (widget_class, "MsdOsdWindow");
+#endif
+
         g_type_class_add_private (klass, sizeof (MsdOsdWindowPrivate));
 }
 

--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -244,9 +244,13 @@ expose_when_composited (GtkWidget *widget, GdkEventExpose *event)
         cairo_surface_t *surface;
         int              width;
         int              height;
+#if GTK_CHECK_VERSION (3, 0, 0)
+        GtkStyleContext *style;
+#else
         GtkStyle        *style;
         GdkColor         color;
         double           r, g, b;
+#endif
 
         window = MSD_OSD_WINDOW (widget);
 
@@ -254,7 +258,11 @@ expose_when_composited (GtkWidget *widget, GdkEventExpose *event)
         context = gdk_cairo_create (gtk_widget_get_window (widget));
 #endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        style = gtk_widget_get_style_context (widget);
+#else
         style = gtk_widget_get_style (widget);
+#endif
         cairo_set_operator (context, CAIRO_OPERATOR_SOURCE);
         gtk_window_get_size (GTK_WINDOW (widget), &width, &height);
 
@@ -271,10 +279,15 @@ expose_when_composited (GtkWidget *widget, GdkEventExpose *event)
         if (cairo_status (cr) != CAIRO_STATUS_SUCCESS) {
                 goto done;
         }
+#if !GTK_CHECK_VERSION (3, 0, 0)
         cairo_set_source_rgba (cr, 1.0, 1.0, 1.0, 0.0);
         cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
         cairo_paint (cr);
+#endif
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gtk_render_background (style, cr, 0, 0, width, height);
+#else
         /* draw a box */
         msd_osd_window_draw_rounded_rectangle (cr, 1.0, 0.5, 0.5, height / 10, width-1, height-1);
         msd_osd_window_color_reverse (&style->bg[GTK_STATE_NORMAL], &color);
@@ -291,6 +304,7 @@ expose_when_composited (GtkWidget *widget, GdkEventExpose *event)
         cairo_set_source_rgba (cr, r, g, b, BG_ALPHA / 2);
         cairo_set_line_width (cr, 1);
         cairo_stroke (cr);
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
         g_signal_emit (window, signals[DRAW_WHEN_COMPOSITED], 0, cr);
@@ -669,6 +683,11 @@ msd_osd_window_init (MsdOsdWindow *window)
 
                 gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
                 gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+                GtkStyleContext *style = gtk_widget_get_style_context (GTK_WIDGET (window));
+                gtk_style_context_add_class (style, "window-frame");
+#endif
 
                 /* assume 130x130 on a 640x480 display and scale from there */
                 scalew = gdk_screen_get_width (screen) / 640.0;


### PR DESCRIPTION
MsdOsdWindow theme example:
MsdOsdWindow.background {
  background-color: rgba(10, 10, 8, 0.75);
}

MsdOsdWindow.window-frame {
    border-radius: 3px;
    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.4);
}