### PR TITLE
Use 'rgba' (LCD subpixel) antialiasing and 'hintslight' by default

### DIFF
--- a/data/org.mate.font-rendering.gschema.xml.in
+++ b/data/org.mate.font-rendering.gschema.xml.in
@@ -28,7 +28,7 @@
       <description>The type of antialiasing to use when rendering fonts. Possible values are: "none" for no antialiasing, "grayscale" for standard grayscale antialiasing, and "rgba" for subpixel antialiasing (LCD screens only).</description>
     </key>
     <key name="hinting" enum="org.mate.font-rendering.Hinting">
-      <default>'medium'</default>
+      <default>'slight'</default>
       <summary>Hinting</summary>
       <description>The type of hinting to use when rendering fonts. Possible values are: "none" for no hinting,  "slight" for basic, "medium" for moderate, and "full" for maximum hinting (may cause distortion of letter forms).</description>
     </key>

--- a/data/org.mate.font-rendering.gschema.xml.in
+++ b/data/org.mate.font-rendering.gschema.xml.in
@@ -23,7 +23,7 @@
       <description>The resolution used for converting font sizes to pixel sizes,  in dots per inch.</description>
     </key>
     <key name="antialiasing" enum="org.mate.font-rendering.Antialiasing">
-      <default>'grayscale'</default>
+      <default>'rgba'</default>
       <summary>Antialiasing</summary>
       <description>The type of antialiasing to use when rendering fonts. Possible values are: "none" for no antialiasing, "grayscale" for standard grayscale antialiasing, and "rgba" for subpixel antialiasing (LCD screens only).</description>
     </key>

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -312,7 +312,7 @@ xft_settings_get (MateXSettingsManager *manager,
 
         settings->antialias = TRUE;
         settings->hinting = TRUE;
-        settings->hintstyle = "hintfull";
+        settings->hintstyle = "hintslight";
         settings->dpi = dpi * 1024; /* Xft wants 1/1024ths of an inch */
         settings->cursor_theme = g_settings_get_string (mouse_gsettings, CURSOR_THEME_KEY);
         settings->cursor_size = g_settings_get_int (mouse_gsettings, CURSOR_SIZE_KEY);


### PR DESCRIPTION
Do this in order to match new default settings of fontconfig and therefore ensure out-of-the-box consistency of font rendering between GTK and non-GTK apps.

### Rationale

Fontconfig 2.11.95 (released 2016-04-06) changed its default hinting style setting to 'hintslight'.

Fontconfig maintainers have done it because:

1. 'hintslight' is clearly the best choice for LCD screens.
2. Many distributions (for example Ubuntu, which is known for good font rendering quality) had been patching fontconfig with this for many years.

So this change, in fact, just upstreams what many distributions had been doing anyway. It affects only these distributions, which hadn't been doing that, for example Arch.

Fontconfig settings are respected by most web browsers, PDF renderers and Qt apps. GTK apps, however, ignore fontconfig settings and use its own font rendering settings (on MATE desktops these settings are controlled by mate-settings-daemon). Having different settings in these two places can lead to inconsistencies in font rendering between GTK and non-GTK apps. There are hundreds of forum posts of users complaining about differences in font rendering between GTK and Qt (mostly Arch users, because Arch doesn't patch its packages with custom default settings).

Aim of this pull request is to change default MATE (GTK) font rendering settings to match default fontconfig settings. This will ensure consistent out-of-the-box font rendering between GTK and non-GTK apps in cases when vanilla fontconfig and mate-settings-daemon packages are being used.

Of course user still will be able to change setting in one of these places and effectively desynchronize GTK and non-GTK rendering.

Also note that this change won't affect Ubuntu (and possibly other distros), because Canonical has been patching both fontconfig and mate-settings-daemon with 'rgba' and 'hintslight' default settings already for many years.