### PR TITLE
port to GtkStyleContext and a few other fixes for warnings

### DIFF
--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -633,6 +633,12 @@ msd_osd_window_constructor (GType                  type,
                       "focus-on-map", FALSE,
                       NULL);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+        GtkWidget *widget = GTK_WIDGET (object);
+        GtkStyleContext *style_context = gtk_widget_get_style_context (widget);
+        gtk_style_context_add_class (style_context, "osd");
+#endif
+
         return object;
 }
 

--- a/plugins/common/msd-osd-window.h
+++ b/plugins/common/msd-osd-window.h
@@ -92,8 +92,10 @@ void                  msd_osd_window_draw_rounded_rectangle (cairo_t *cr,
                                                              gdouble  width,
                                                              gdouble  height);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void                  msd_osd_window_color_reverse          (const GdkColor *a,
                                                              GdkColor       *b);
+#endif
 
 #ifdef __cplusplus
 }

--- a/plugins/mouse/msd-locate-pointer.c
+++ b/plugins/mouse/msd-locate-pointer.c
@@ -55,18 +55,30 @@ locate_pointer_paint (MsdLocatePointerData *data,
 		      cairo_t              *cr,
 		      gboolean              composite)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+  GdkRGBA color;
+  gdouble progress, circle_progress;
+  gint width, height, i;
+  GtkStyleContext *context;
+#else
   GdkColor color;
   gdouble progress, circle_progress;
   gint width, height, i;
   GtkStyle *style;
+#endif
 
   progress = data->progress;
 
   width = gdk_window_get_width (data->window);
   height = gdk_window_get_height (data->window);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+  context = gtk_widget_get_style_context (data->widget);
+  gtk_style_context_get_background_color (context, GTK_STATE_FLAG_SELECTED, &color);
+#else
   style = gtk_widget_get_style (data->widget);
   color = style->bg[GTK_STATE_SELECTED];
+#endif
 
   cairo_set_source_rgba (cr, 1., 1., 1., 0.);
   cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
@@ -86,9 +98,15 @@ locate_pointer_paint (MsdLocatePointerData *data,
       if (composite)
 	{
 	  cairo_set_source_rgba (cr,
+#if GTK_CHECK_VERSION (3, 0, 0)
+				 color.red,
+				 color.green,
+				 color.blue,
+#else
 				 color.red / 65535.,
 				 color.green / 65535.,
 				 color.blue / 65535.,
+#endif
 				 1 - circle_progress);
 	  cairo_arc (cr,
 		     width / 2,

--- a/plugins/mouse/msd-locate-pointer.c
+++ b/plugins/mouse/msd-locate-pointer.c
@@ -50,6 +50,26 @@ struct MsdLocatePointerData
 
 static MsdLocatePointerData *data = NULL;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
+static void
+msd_get_background_color (GtkStyleContext *context,
+                          GtkStateFlags    state,
+                          GdkRGBA         *color)
+{
+    GdkRGBA *c;
+
+    g_return_if_fail (color != NULL);
+    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+
+    gtk_style_context_get (context,
+                           state,
+                           "background-color", &c,
+                           NULL);
+    *color = *c;
+    gdk_rgba_free (c);
+}
+#endif
+
 static void
 locate_pointer_paint (MsdLocatePointerData *data,
 		      cairo_t              *cr,
@@ -74,7 +94,7 @@ locate_pointer_paint (MsdLocatePointerData *data,
 
 #if GTK_CHECK_VERSION (3, 0, 0)
   context = gtk_widget_get_style_context (data->widget);
-  gtk_style_context_get_background_color (context, GTK_STATE_FLAG_SELECTED, &color);
+  msd_get_background_color (context, GTK_STATE_FLAG_SELECTED, &color);
 #else
   style = gtk_widget_get_style (data->widget);
   color = style->bg[GTK_STATE_SELECTED];

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -496,7 +496,7 @@ update_xft_settings (MateXSettingsManager *manager)
 
 static void
 xft_callback (GSettings            *gsettings,
-              gchar                *key,
+              const gchar          *key,
               MateXSettingsManager *manager)
 {
         int i;


### PR DESCRIPTION
- complete port of media-keys to GtkStyleContext
- port msd-locate-pointer to GtkStyleContext
- add OSD style class to media-keys
- media-keys: do not use a hard coded setting for for all elements of the OSD window
- media-keys: fixes a -Wincompatible-pointer-types warning from previous commit
- mouse: fix deprecated gtk_style_context_get_background_color
- xsettings: fix build warning -Wdiscarded-qualifiers

Mainly our OSD windows use now osd settings from themes instead of old hard coded setting from gtk2 code which didn't work for gtk3.
If your theme does not support osd well than you can use this example setting.
```
MsdOsdWindow.background.osd {
    border-radius: 10%;
}

MsdOsdWindow.background.osd.trough {
	background-color: @osd_trough_bg;
    border-style: solid;
    border-width: 1px;
	border-color: shade (@theme_selected_bg_color, 0.4);
}

MsdOsdWindow.background.osd.progressbar {
	background-color: @theme_selected_bg_color;
}
```
This works for all gtk+3 versions, no need to change something for >= gtk+-3.20  :)
Note, our themes use wrong selectors for OSD in 3.20/22/master branch, but with previous gtk+ versions they work out of box.
I will fix that soon.
Btw. this is all for using compositor, w/o compositor it use some hard coded stuff.
But fixing that is the next step, i don't want to make the PR more huge.

@dnk 
I don't think we need the style class .window-frame after you add .osd class.
Double setting.

@monsta @lukefromdc @dnk 
Please test.
If you want to make an improvement please commit or do a PR here ;)