### PR TITLE
GTK 3.21: Fix background changing, caja startup

### DIFF
--- a/plugins/background/msd-background-manager.c
+++ b/plugins/background/msd-background-manager.c
@@ -67,7 +67,9 @@ struct MsdBackgroundManagerPrivate {
 	GList           *scr_sizes;
 
 	gboolean         msd_can_draw;
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	gboolean         caja_can_draw;
+#endif
 	gboolean         do_fade;
 	gboolean         draw_in_progress;
 
@@ -95,6 +97,7 @@ can_fade_bg (MsdBackgroundManager *manager)
 	return g_settings_get_boolean (manager->priv->settings, MATE_BG_KEY_BACKGROUND_FADE);
 }
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 /* Whether Caja is configured to draw desktop (show-desktop-icons) */
 static gboolean
 caja_can_draw_bg (MsdBackgroundManager *manager)
@@ -158,7 +161,7 @@ caja_is_drawing_bg (MsdBackgroundManager *manager)
 
 	return running;
 }
-
+#endif
 static void
 free_fade (MsdBackgroundManager *manager)
 {
@@ -218,7 +221,10 @@ draw_background (MsdBackgroundManager *manager,
 {
 	MsdBackgroundManagerPrivate *p = manager->priv;
 
-#if !GTK_CHECK_VERSION(3, 21, 0)
+#if GTK_CHECK_VERSION(3, 21, 0)
+        if (!p->msd_can_draw || p->draw_in_progress)
+		return;
+#else
 	if (!p->msd_can_draw || p->draw_in_progress || caja_is_drawing_bg (manager))
 		return;
 #endif
@@ -264,10 +270,13 @@ on_screen_size_changed (GdkScreen            *screen,
 			MsdBackgroundManager *manager)
 {
 	MsdBackgroundManagerPrivate *p = manager->priv;
-
+#if GTK_CHECK_VERSION(3, 21, 0)
+        if (!p->msd_can_draw || p->draw_in_progress)
+                return;
+#else
 	if (!p->msd_can_draw || p->draw_in_progress || caja_is_drawing_bg (manager))
 		return;
-
+#endif
 	gint scr_num = gdk_screen_get_number (screen);
 	gchar *old_size = g_list_nth_data (manager->priv->scr_sizes, scr_num);
 	gchar *new_size = g_strdup_printf ("%dx%d", gdk_screen_get_width (screen),
@@ -338,14 +347,20 @@ settings_change_event_cb (GSettings            *settings,
 
 	/* Complements on_bg_handling_changed() */
 	p->msd_can_draw = msd_can_draw_bg (manager);
+#if GTK_CHECK_VERSION(3, 21, 0)
+	if (p->msd_can_draw && p->bg != NULL)
+	{
+		/* Defer signal processing to avoid making the dconf backend deadlock */
+		g_idle_add ((GSourceFunc) settings_change_event_idle_cb, manager);
+	}
+#else
 	p->caja_can_draw = caja_can_draw_bg (manager);
-
 	if (p->msd_can_draw && p->bg != NULL && !caja_is_drawing_bg (manager))
 	{
 		/* Defer signal processing to avoid making the dconf backend deadlock */
 		g_idle_add ((GSourceFunc) settings_change_event_idle_cb, manager);
 	}
-
+#endif
 	return FALSE;   /* let the event propagate further */
 }
 
@@ -511,7 +526,9 @@ msd_background_manager_start (MsdBackgroundManager  *manager,
 	p->settings = g_settings_new (MATE_BG_SCHEMA);
 
 	p->msd_can_draw = msd_can_draw_bg (manager);
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	p->caja_can_draw = caja_can_draw_bg (manager);
+#endif
 
 	g_signal_connect (p->settings, "changed::" MATE_BG_KEY_DRAW_BACKGROUND,
 			  G_CALLBACK (on_bg_handling_changed), manager);
@@ -524,14 +541,19 @@ msd_background_manager_start (MsdBackgroundManager  *manager,
 	 */
 	if (p->msd_can_draw)
 	{
+#if !GTK_CHECK_VERSION(3, 21, 0)
 		if (p->caja_can_draw)
 		{
+
 			draw_bg_after_session_loads (manager);
 		}
 		else
 		{
+#endif
 			setup_background (manager);
+#if !GTK_CHECK_VERSION(3, 21, 0)
 		}
+#endif
 	}
 
 	mate_settings_profile_end (NULL);

--- a/plugins/background/msd-background-manager.c
+++ b/plugins/background/msd-background-manager.c
@@ -218,9 +218,10 @@ draw_background (MsdBackgroundManager *manager,
 {
 	MsdBackgroundManagerPrivate *p = manager->priv;
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	if (!p->msd_can_draw || p->draw_in_progress || caja_is_drawing_bg (manager))
 		return;
-
+#endif
 	mate_settings_profile_start (NULL);
 
 	GdkDisplay *display   = gdk_display_get_default ();
@@ -402,7 +403,7 @@ on_bg_handling_changed (GSettings            *settings,
 	MsdBackgroundManagerPrivate *p = manager->priv;
 
 	mate_settings_profile_start (NULL);
-
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	if (caja_is_drawing_bg (manager))
 	{
 		if (p->bg != NULL)
@@ -410,9 +411,11 @@ on_bg_handling_changed (GSettings            *settings,
 	}
 	else if (p->msd_can_draw && p->bg == NULL)
 	{
+#endif
 		setup_background (manager);
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	}
-
+#endif
 	mate_settings_profile_end (NULL);
 }
 


### PR DESCRIPTION
Make sure m-s-d knows to draw the background unconditionally when used with transparent version of Caja for GTK 3.21 or later.  Fix background changing with or without caja running. Remove all references to Caja from GTK 3.21 or later builds, remove resulting unused variable. Note that fading between backgrounds does not work in GTK 3.21 in this PR nor in master with caja not running, this appears to be an issue in mate-desktop with GTK 3.21.

Apply all of this only to GTK 3.21 or later builds, same as for https://github.com/mate-desktop/caja/pull/602 in Caja. These are meant to be used together, and not to disturb the perfectly good background handling in GTK 3.20 or earlier builds