### PR TITLE
new touchpad settings

### DIFF
--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -75,5 +75,15 @@
       <summary>Touchpad button orientation</summary>
       <description>Swap left and right buttons for left-handed touchpads with 'left', 'right' for right-handed, 'mouse' to follow the mouse setting.</description>
     </key>
+    <key name="motion-acceleration" type="d">
+      <default>-1</default>
+      <summary>Single Click</summary>
+      <description>Acceleration multiplier for touchpad motion.  A value of -1 is the system default.</description>
+    </key>
+    <key name="motion-threshold" type="i">
+      <default>-1</default>
+      <summary>Motion Threshold</summary>
+      <description>Distance in pixels the pointer must move before accelerated touchpad motion is activated.  A value of -1 is the system default.</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -1,4 +1,9 @@
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
+  <enum id="org.mate.peripherals-touchpad.Handedness">
+    <value nick="right" value="0"/>
+    <value nick="left" value="1"/>
+    <value nick="mouse" value="2"/>
+  </enum>
   <schema id="org.mate.peripherals-touchpad" path="/org/mate/desktop/peripherals/touchpad/">
     <key name="disable-while-typing" type="b">
       <default>false</default>
@@ -64,6 +69,11 @@
       <default>2</default>
       <summary>Three finger tap button</summary>
       <description>Select the button mapping for three-finger tap. Supported values are: 1: left mouse button 2: middle mouse button 3: right mouse button</description>
+    </key>
+    <key name="left-handed" enum="org.mate.peripherals-touchpad.Handedness">
+      <default>'mouse'</default>
+      <summary>Touchpad button orientation</summary>
+      <description>Swap left and right buttons for left-handed touchpads with 'left', 'right' for right-handed, 'mouse' to follow the mouse setting.</description>
     </key>
   </schema>
 </schemalist>

--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -77,7 +77,7 @@
     </key>
     <key name="motion-acceleration" type="d">
       <default>-1</default>
-      <summary>Single Click</summary>
+      <summary>Motion Acceleration</summary>
       <description>Acceleration multiplier for touchpad motion.  A value of -1 is the system default.</description>
     </key>
     <key name="motion-threshold" type="i">

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -52,11 +52,11 @@
 
 /* Keys with same names for both touchpad and mouse */
 #define KEY_LEFT_HANDED                  "left-handed"          /*  a boolean for mouse, an enum for touchpad */
+#define KEY_MOTION_ACCELERATION          "motion-acceleration"
+#define KEY_MOTION_THRESHOLD             "motion-threshold"
 
 /* Mouse settings */
 #define MATE_MOUSE_SCHEMA                "org.mate.peripherals-mouse"
-#define KEY_MOUSE_MOTION_ACCELERATION    "motion-acceleration"
-#define KEY_MOUSE_MOTION_THRESHOLD       "motion-threshold"
 #define KEY_MOUSE_LOCATE_POINTER         "locate-pointer"
 #define KEY_MIDDLE_BUTTON_EMULATION      "middle-button-enabled"
 
@@ -983,8 +983,8 @@ set_mouse_settings (MsdMouseManager *manager)
         gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
         set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
 
-        set_motion_acceleration (manager, g_settings_get_double (manager->priv->settings_mouse, KEY_MOUSE_MOTION_ACCELERATION));
-        set_motion_threshold (manager, g_settings_get_int (manager->priv->settings_mouse, KEY_MOUSE_MOTION_THRESHOLD));
+        set_motion_acceleration (manager, g_settings_get_double (manager->priv->settings_mouse, KEY_MOTION_ACCELERATION));
+        set_motion_threshold (manager, g_settings_get_int (manager->priv->settings_mouse, KEY_MOTION_THRESHOLD));
         set_middle_button_all (manager, g_settings_get_boolean (manager->priv->settings_mouse, KEY_MIDDLE_BUTTON_EMULATION));
 
         set_disable_w_typing (manager, g_settings_get_boolean (manager->priv->settings_touchpad, KEY_TOUCHPAD_DISABLE_W_TYPING));
@@ -1005,9 +1005,9 @@ mouse_callback (GSettings          *settings,
                 gboolean mouse_left_handed = g_settings_get_boolean (settings, key);
                 gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
                 set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
-        } else if (g_strcmp0 (key, KEY_MOUSE_MOTION_ACCELERATION) == 0) {
+        } else if (g_strcmp0 (key, KEY_MOTION_ACCELERATION) == 0) {
                 set_motion_acceleration (manager, g_settings_get_double (settings, key));
-        } else if (g_strcmp0 (key, KEY_MOUSE_MOTION_THRESHOLD) == 0) {
+        } else if (g_strcmp0 (key, KEY_MOTION_THRESHOLD) == 0) {
                 set_motion_threshold (manager, g_settings_get_int (settings, key));
         } else if (g_strcmp0 (key, KEY_MIDDLE_BUTTON_EMULATION) == 0) {
                 set_middle_button_all (manager, g_settings_get_boolean (settings, key));

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -50,16 +50,19 @@
 
 #define MSD_MOUSE_MANAGER_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MOUSE_MANAGER, MsdMouseManagerPrivate))
 
+/* Keys with same names for both touchpad and mouse */
+#define KEY_LEFT_HANDED                  "left-handed"          /*  a boolean for mouse, an enum for touchpad */
+
+/* Mouse settings */
 #define MATE_MOUSE_SCHEMA                "org.mate.peripherals-mouse"
-#define KEY_MOUSE_LEFT_HANDED            "left-handed"
 #define KEY_MOUSE_MOTION_ACCELERATION    "motion-acceleration"
 #define KEY_MOUSE_MOTION_THRESHOLD       "motion-threshold"
 #define KEY_MOUSE_LOCATE_POINTER         "locate-pointer"
 #define KEY_MIDDLE_BUTTON_EMULATION      "middle-button-enabled"
 
+/* Touchpad settings */
 #define MATE_TOUCHPAD_SCHEMA             "org.mate.peripherals-touchpad"
 #define KEY_TOUCHPAD_DISABLE_W_TYPING    "disable-while-typing"
- 
 #define KEY_TOUCHPAD_TWO_FINGER_CLICK    "two-finger-click"
 #define KEY_TOUCHPAD_THREE_FINGER_CLICK  "three-finger-click"
 #define KEY_TOUCHPAD_NATURAL_SCROLL      "natural-scroll"
@@ -72,7 +75,6 @@
 #define KEY_VERT_TWO_FINGER_SCROLL       "vertical-two-finger-scrolling"
 #define KEY_HORIZ_TWO_FINGER_SCROLL      "horizontal-two-finger-scrolling"
 #define KEY_TOUCHPAD_ENABLED             "touchpad-enabled"
-#define KEY_TOUCHPAD_LEFT_HANDED         "left-handed"      /* NOTE: here it's enum, not boolean */
 
 
 #if 0   /* FIXME need to fork (?) mousetweaks for this to work */
@@ -541,7 +543,7 @@ static gboolean
 get_touchpad_handedness (MsdMouseManager *manager,
                          gboolean         mouse_left_handed)
 {
-        switch (g_settings_get_enum (manager->priv->settings_touchpad, KEY_TOUCHPAD_LEFT_HANDED)) {
+        switch (g_settings_get_enum (manager->priv->settings_touchpad, KEY_LEFT_HANDED)) {
         case TOUCHPAD_HANDEDNESS_RIGHT:
                 return FALSE;
         case TOUCHPAD_HANDEDNESS_LEFT:
@@ -619,7 +621,7 @@ set_tap_to_click_all (MsdMouseManager *manager)
                 return;
 
         gboolean state = g_settings_get_boolean (manager->priv->settings_touchpad, KEY_TOUCHPAD_TAP_TO_CLICK);
-        gboolean left_handed = get_touchpad_handedness (manager, g_settings_get_boolean (manager->priv->settings_mouse, KEY_MOUSE_LEFT_HANDED));
+        gboolean left_handed = get_touchpad_handedness (manager, g_settings_get_boolean (manager->priv->settings_mouse, KEY_LEFT_HANDED));
         gint one_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_ONE_FINGER_TAP);
         gint two_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_TWO_FINGER_TAP);
         gint three_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_THREE_FINGER_TAP);
@@ -977,7 +979,7 @@ set_mousetweaks_daemon (MsdMouseManager *manager,
 static void
 set_mouse_settings (MsdMouseManager *manager)
 {
-        gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, KEY_MOUSE_LEFT_HANDED);
+        gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, KEY_LEFT_HANDED);
         gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
         set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
 
@@ -999,7 +1001,7 @@ mouse_callback (GSettings          *settings,
                 const gchar        *key,
                 MsdMouseManager    *manager)
 {
-        if (g_strcmp0 (key, KEY_MOUSE_LEFT_HANDED) == 0) {
+        if (g_strcmp0 (key, KEY_LEFT_HANDED) == 0) {
                 gboolean mouse_left_handed = g_settings_get_boolean (settings, key);
                 gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
                 set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
@@ -1032,8 +1034,8 @@ touchpad_callback (GSettings          *settings,
 {
         if (g_strcmp0 (key, KEY_TOUCHPAD_DISABLE_W_TYPING) == 0) {
                 set_disable_w_typing (manager, g_settings_get_boolean (settings, key));
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_LEFT_HANDED) == 0) {
-                gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, KEY_MOUSE_LEFT_HANDED);
+        } else if (g_strcmp0 (key, KEY_LEFT_HANDED) == 0) {
+                gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, key);
                 gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
                 set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
         } else if ((g_strcmp0 (key, KEY_TOUCHPAD_TAP_TO_CLICK) == 0)

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -1013,11 +1013,11 @@ mouse_callback (GSettings          *settings,
                 set_motion_threshold (manager, g_settings_get_int (settings, key));
         } else if (g_strcmp0 (key, KEY_TOUCHPAD_DISABLE_W_TYPING) == 0) {
                 set_disable_w_typing (manager, g_settings_get_boolean (settings, key));
-        } else if (g_str_equal (key, KEY_MIDDLE_BUTTON_EMULATION)) {
+        } else if (g_strcmp0 (key, KEY_MIDDLE_BUTTON_EMULATION) == 0) {
                 set_middle_button_all (manager, g_settings_get_boolean (settings, key));
         } else if (g_strcmp0 (key, KEY_TOUCHPAD_TAP_TO_CLICK) == 0) {
                 set_tap_to_click_all (manager);
-        } else if (g_str_equal (key, KEY_TOUCHPAD_TWO_FINGER_CLICK) || g_str_equal (key, KEY_TOUCHPAD_THREE_FINGER_CLICK)) {
+        } else if ((g_strcmp0 (key, KEY_TOUCHPAD_TWO_FINGER_CLICK) == 0) || (g_strcmp0 (key, KEY_TOUCHPAD_THREE_FINGER_CLICK) == 0)) {
                 set_click_actions_all (manager);
         } else if (g_strcmp0 (key, KEY_TOUCHPAD_ONE_FINGER_TAP) == 0) {
                 set_tap_to_click_all (manager);
@@ -1027,7 +1027,7 @@ mouse_callback (GSettings          *settings,
                 set_tap_to_click_all (manager);
         } else if (g_strcmp0 (key, KEY_VERT_EDGE_SCROLL) == 0 || g_strcmp0 (key, KEY_HORIZ_EDGE_SCROLL) == 0 || g_strcmp0 (key, KEY_VERT_TWO_FINGER_SCROLL) == 0 || g_strcmp0 (key, KEY_HORIZ_TWO_FINGER_SCROLL) == 0) {
                 set_scrolling (manager->priv->settings_touchpad);
-        } else if (g_str_equal (key, KEY_TOUCHPAD_NATURAL_SCROLL)) {
+        } else if (g_strcmp0 (key, KEY_TOUCHPAD_NATURAL_SCROLL) == 0) {
                 set_natural_scroll_all (manager);
         } else if (g_strcmp0 (key, KEY_MOUSE_LOCATE_POINTER) == 0) {
                 set_locate_pointer (manager, g_settings_get_boolean (settings, key));

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -1003,36 +1003,14 @@ mouse_callback (GSettings          *settings,
                 gboolean mouse_left_handed = g_settings_get_boolean (settings, key);
                 gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
                 set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_LEFT_HANDED) == 0) {
-                gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, KEY_MOUSE_LEFT_HANDED);
-                gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
-                set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
         } else if (g_strcmp0 (key, KEY_MOUSE_MOTION_ACCELERATION) == 0) {
                 set_motion_acceleration (manager, g_settings_get_double (settings, key));
         } else if (g_strcmp0 (key, KEY_MOUSE_MOTION_THRESHOLD) == 0) {
                 set_motion_threshold (manager, g_settings_get_int (settings, key));
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_DISABLE_W_TYPING) == 0) {
-                set_disable_w_typing (manager, g_settings_get_boolean (settings, key));
         } else if (g_strcmp0 (key, KEY_MIDDLE_BUTTON_EMULATION) == 0) {
                 set_middle_button_all (manager, g_settings_get_boolean (settings, key));
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_TAP_TO_CLICK) == 0) {
-                set_tap_to_click_all (manager);
-        } else if ((g_strcmp0 (key, KEY_TOUCHPAD_TWO_FINGER_CLICK) == 0) || (g_strcmp0 (key, KEY_TOUCHPAD_THREE_FINGER_CLICK) == 0)) {
-                set_click_actions_all (manager);
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_ONE_FINGER_TAP) == 0) {
-                set_tap_to_click_all (manager);
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_TWO_FINGER_TAP) == 0) {
-                set_tap_to_click_all (manager);
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_THREE_FINGER_TAP) == 0) {
-                set_tap_to_click_all (manager);
-        } else if (g_strcmp0 (key, KEY_VERT_EDGE_SCROLL) == 0 || g_strcmp0 (key, KEY_HORIZ_EDGE_SCROLL) == 0 || g_strcmp0 (key, KEY_VERT_TWO_FINGER_SCROLL) == 0 || g_strcmp0 (key, KEY_HORIZ_TWO_FINGER_SCROLL) == 0) {
-                set_scrolling (manager->priv->settings_touchpad);
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_NATURAL_SCROLL) == 0) {
-                set_natural_scroll_all (manager);
         } else if (g_strcmp0 (key, KEY_MOUSE_LOCATE_POINTER) == 0) {
                 set_locate_pointer (manager, g_settings_get_boolean (settings, key));
-        } else if (g_strcmp0 (key, KEY_TOUCHPAD_ENABLED) == 0) {
-                set_touchpad_enabled_all (g_settings_get_boolean (settings, key));
 #if 0   /* FIXME need to fork (?) mousetweaks for this to work */
         } else if (g_strcmp0 (key, KEY_MOUSE_A11Y_DWELL_ENABLE) == 0) {
                 set_mousetweaks_daemon (manager,
@@ -1044,6 +1022,37 @@ mouse_callback (GSettings          *settings,
                                         g_settings_get_boolean (settings, KEY_MOUSE_A11Y_DWELL_ENABLE, NULL),
                                         g_settings_get_boolean (settings, key));
 #endif
+        }
+}
+
+static void
+touchpad_callback (GSettings          *settings,
+                   const gchar        *key,
+                   MsdMouseManager    *manager)
+{
+        if (g_strcmp0 (key, KEY_TOUCHPAD_DISABLE_W_TYPING) == 0) {
+                set_disable_w_typing (manager, g_settings_get_boolean (settings, key));
+        } else if (g_strcmp0 (key, KEY_TOUCHPAD_LEFT_HANDED) == 0) {
+                gboolean mouse_left_handed = g_settings_get_boolean (manager->priv->settings_mouse, KEY_MOUSE_LEFT_HANDED);
+                gboolean touchpad_left_handed = get_touchpad_handedness (manager, mouse_left_handed);
+                set_left_handed_all (manager, mouse_left_handed, touchpad_left_handed);
+        } else if ((g_strcmp0 (key, KEY_TOUCHPAD_TAP_TO_CLICK) == 0)
+                || (g_strcmp0 (key, KEY_TOUCHPAD_ONE_FINGER_TAP) == 0)
+                || (g_strcmp0 (key, KEY_TOUCHPAD_TWO_FINGER_TAP) == 0)
+                || (g_strcmp0 (key, KEY_TOUCHPAD_THREE_FINGER_TAP) == 0)) {
+                set_tap_to_click_all (manager);
+        } else if ((g_strcmp0 (key, KEY_TOUCHPAD_TWO_FINGER_CLICK) == 0)
+                || (g_strcmp0 (key, KEY_TOUCHPAD_THREE_FINGER_CLICK) == 0)) {
+                set_click_actions_all (manager);
+        } else if ((g_strcmp0 (key, KEY_VERT_EDGE_SCROLL) == 0)
+                || (g_strcmp0 (key, KEY_HORIZ_EDGE_SCROLL) == 0)
+                || (g_strcmp0 (key, KEY_VERT_TWO_FINGER_SCROLL) == 0)
+                || (g_strcmp0 (key, KEY_HORIZ_TWO_FINGER_SCROLL) == 0)) {
+                set_scrolling (manager->priv->settings_touchpad);
+        } else if (g_strcmp0 (key, KEY_TOUCHPAD_NATURAL_SCROLL) == 0) {
+                set_natural_scroll_all (manager);
+        } else if (g_strcmp0 (key, KEY_TOUCHPAD_ENABLED) == 0) {
+                set_touchpad_enabled_all (g_settings_get_boolean (settings, key));
         }
 }
 
@@ -1064,7 +1073,7 @@ msd_mouse_manager_idle_cb (MsdMouseManager *manager)
         g_signal_connect (manager->priv->settings_mouse, "changed",
                           G_CALLBACK (mouse_callback), manager);
         g_signal_connect (manager->priv->settings_touchpad, "changed",
-                          G_CALLBACK (mouse_callback), manager);
+                          G_CALLBACK (touchpad_callback), manager);
 
         manager->priv->syndaemon_spawned = FALSE;
 


### PR DESCRIPTION
This adds some new settings for touchpad: handedness (right/left/follow mouse), motion-acceleration and motion-threshold.

Handedness setting has the default value to follow the corresponding mouse setting, so the default behavior will be the same.

Motion settings previously were applied to both mouse and touchpad at the same time once you set it in mate-mouse-properties (or in dconf-editor). Now touchpad settings are separated from mouse ones, and they have to be set separately.

@clefebvre @flexiondotorg @raveit65 @XRevan86 @sc0w @lukefromdc
Please test it guys if you can.