### PR TITLE
OSD: fix rendering on noncomposited desktop

### DIFF
--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -207,8 +207,7 @@ draw_when_not_composited (GtkWidget *widget, cairo_t *cr)
         int width;
         int height;
 
-        width = gtk_widget_get_allocated_width (widget);
-        height = gtk_widget_get_allocated_width (widget);
+        gtk_window_get_size (GTK_WINDOW (widget), &width, &height);
         context = gtk_widget_get_style_context (widget);
 
         gtk_style_context_set_state (context, GTK_STATE_FLAG_ACTIVE);

--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -211,6 +211,7 @@ draw_when_not_composited (GtkWidget *widget, cairo_t *cr)
         context = gtk_widget_get_style_context (widget);
 
         gtk_style_context_set_state (context, GTK_STATE_FLAG_ACTIVE);
+        gtk_style_context_add_class(context,"msd-osd-window-solid");
         gtk_render_frame (context,
                           cr,
                           0,


### PR DESCRIPTION
Fix for https://github.com/mate-desktop/mate-settings-daemon/issues/163

Use same function to get width and height as in the composited case. gtk_widget_get_allocated_width/height seems to cause a lot of problems in GTK3 