### PR TITLE
add libinput support for mouse and touchpad

### DIFF
--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -243,6 +243,40 @@ touchpad_has_single_button (XDevice *device)
         return is_single_button;
 }
 
+static gboolean
+property_exists_on_device (XDeviceInfo *device_info,
+                           const char  *property_name)
+{
+        XDevice *device;
+        int rc;
+        Atom type, prop;
+        int format;
+        unsigned long nitems, bytes_after;
+        unsigned char *data;
+
+        prop = property_from_name (property_name);
+        if (!prop)
+                return FALSE;
+
+        gdk_error_trap_push ();
+        device = XOpenDevice (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), device_info->id);
+        if ((gdk_error_trap_pop () != 0) || (device == NULL))
+                return FALSE;
+
+        gdk_error_trap_push ();
+        rc = XGetDeviceProperty (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+                                 device, prop, 0, 1, False, XA_INTEGER, &type, &format,
+                                 &nitems, &bytes_after, &data);
+
+        if (rc == Success)
+                XFree (data);
+
+        XCloseDevice (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), device);
+        gdk_error_trap_pop_ignored ();
+
+        return rc == Success;
+}
+
 static void
 property_set_bool (XDeviceInfo *device_info,
                    XDevice     *device,

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -811,8 +811,8 @@ set_click_actions_all (MsdMouseManager *manager)
 }
 
 static void
-set_natural_scroll (XDeviceInfo     *device_info,
-                    gboolean         natural_scroll)
+set_natural_scroll_synaptics (XDeviceInfo *device_info,
+                              gboolean     natural_scroll)
 {
         XDevice *device;
         int format, rc;
@@ -860,6 +860,25 @@ set_natural_scroll (XDeviceInfo     *device_info,
         }
 }
 
+static void
+set_natural_scroll_libinput (XDeviceInfo *device_info,
+                             gboolean     natural_scroll)
+{
+        g_debug ("Trying to set %s for \"%s\"", natural_scroll ? "natural (reverse) scroll" : "normal scroll", device_info->name);
+
+        touchpad_set_bool (device_info, "libinput Natural Scrolling Enabled", 0, natural_scroll);
+}
+
+static void
+set_natural_scroll (XDeviceInfo *device_info,
+                    gboolean     natural_scroll)
+{
+        if (property_from_name ("Synaptics Scrolling Distance"))
+                set_natural_scroll_synaptics (device_info, natural_scroll);
+
+        if (property_from_name ("libinput Natural Scrolling Enabled"))
+                set_natural_scroll_libinput (device_info, natural_scroll);
+}
 
 static void
 set_natural_scroll_all (MsdMouseManager *manager)

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -107,7 +107,7 @@ static void     msd_mouse_manager_class_init  (MsdMouseManagerClass *klass);
 static void     msd_mouse_manager_init        (MsdMouseManager      *mouse_manager);
 static void     msd_mouse_manager_finalize    (GObject             *object);
 static void     set_mouse_settings            (MsdMouseManager      *manager);
-static void     set_tap_to_click              (XDeviceInfo          *device_info,
+static void     set_tap_to_click_synaptics    (XDeviceInfo          *device_info,
                                                gboolean              state,
                                                gboolean              left_handed,
                                                gint                  one_finger_tap,
@@ -366,7 +366,7 @@ set_left_handed_legacy_driver (MsdMouseManager *manager,
                         gint one_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_ONE_FINGER_TAP);
                         gint two_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_TWO_FINGER_TAP);
                         gint three_finger_tap = g_settings_get_int (manager->priv->settings_touchpad, KEY_TOUCHPAD_THREE_FINGER_TAP);
-                        set_tap_to_click (device_info, tap, left_handed, one_finger_tap, two_finger_tap, three_finger_tap);
+                        set_tap_to_click_synaptics (device_info, tap, left_handed, one_finger_tap, two_finger_tap, three_finger_tap);
                 }
 
                 XCloseDevice (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), device);

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -710,12 +710,12 @@ get_touchpad_handedness (MsdMouseManager *manager,
 }
 
 static void
-set_tap_to_click (XDeviceInfo     *device_info,
-                  gboolean         state,
-                  gboolean         left_handed,
-                  gint             one_finger_tap,
-                  gint             two_finger_tap,
-                  gint             three_finger_tap)
+set_tap_to_click_synaptics (XDeviceInfo *device_info,
+                            gboolean     state,
+                            gboolean     left_handed,
+                            gint         one_finger_tap,
+                            gint         two_finger_tap,
+                            gint         three_finger_tap)
 {
         XDevice *device;
         int format, rc;
@@ -762,6 +762,29 @@ set_tap_to_click (XDeviceInfo     *device_info,
         if (gdk_error_trap_pop ()) {
                 g_warning ("Error in setting tap to click on \"%s\"", device_info->name);
         }
+}
+
+static void
+set_tap_to_click_libinput (XDeviceInfo *device_info,
+                           gboolean     state)
+{
+        touchpad_set_bool (device_info, "libinput Tapping Enabled", 0, state);
+}
+
+static void
+set_tap_to_click (XDeviceInfo *device_info,
+                  gboolean     state,
+                  gboolean     left_handed,
+                  gint         one_finger_tap,
+                  gint         two_finger_tap,
+                  gint         three_finger_tap)
+{
+        if (property_from_name ("Synaptics Tap Action"))
+                set_tap_to_click_synaptics (device_info, state, left_handed,
+                                            one_finger_tap, two_finger_tap, three_finger_tap);
+
+        if (property_from_name ("libinput Tapping Enabled"))
+                set_tap_to_click_libinput (device_info, state);
 }
 
 static void


### PR DESCRIPTION
This is backported from https://github.com/linuxmint/cinnamon-settings-daemon/pull/131 (big thanks to @whot for this).

@clefebvre @flexiondotorg @raveit65 @XRevan86 @sc0w @lukefromdc
Please test it guys if you can. You'll need libinput driver for Xorg installed and taking priority over evdev and Synaptics. You can use ```xinput``` tool to check device properties and their values. For example, here's how my old mouse is shown:

```
monsta@asylum ~ $ xinput --list
⎡ Virtual core pointer                    	id=2	[master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer              	id=4	[slave  pointer  (2)]
⎜   ↳ Logitech USB-PS/2 Optical Mouse         	id=8	[slave  pointer  (2)]
⎣ Virtual core keyboard                   	id=3	[master keyboard (2)]
    ↳ Virtual core XTEST keyboard             	id=5	[slave  keyboard (3)]
    ↳ Power Button                            	id=6	[slave  keyboard (3)]
    ↳ Power Button                            	id=7	[slave  keyboard (3)]
    ↳ AT Translated Set 2 keyboard            	id=9	[slave  keyboard (3)]
```
```
monsta@asylum ~ $ xinput --list-props 8
Device 'Logitech USB-PS/2 Optical Mouse':
	Device Enabled (152):	1
	Coordinate Transformation Matrix (154):	1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
	libinput Accel Speed (285):	-0.069767
	libinput Accel Speed Default (286):	0.000000
	libinput Accel Profiles Available (287):	1, 1
	libinput Accel Profile Enabled (288):	1, 0
	libinput Accel Profile Enabled Default (289):	1, 0
	libinput Natural Scrolling Enabled (290):	0
	libinput Natural Scrolling Enabled Default (291):	0
	libinput Send Events Modes Available (269):	1, 0
	libinput Send Events Mode Enabled (270):	0, 0
	libinput Send Events Mode Enabled Default (271):	0, 0
	libinput Left Handed Enabled (292):	0
	libinput Left Handed Enabled Default (293):	0
	libinput Scroll Methods Available (294):	0, 0, 1
	libinput Scroll Method Enabled (295):	0, 0, 0
	libinput Scroll Method Enabled Default (296):	0, 0, 0
	libinput Button Scrolling Button (297):	2
	libinput Button Scrolling Button Default (298):	274
	libinput Middle Emulation Enabled (299):	1
	libinput Middle Emulation Enabled Default (300):	0
	Device Node (272):	"/dev/input/event3"
	Device Product ID (273):	1133, 49214
	libinput Drag Lock Buttons (301):	<no items>
	libinput Horizonal Scroll Enabled (274):	1
```

Since m-c-c doesn't have libinput support yet (for example, it only checks for Synaptics presence to determine whether to show touchpad settings tab), you'll probably have to use other tools for changing GSettings keys in ```org.mate.peripherals-mouse``` and ```org.mate.peripherals-touchpad``` schemas.

Here are some details about differences between old code (for evdev and Synaptics) and libinput support code. Sorry @whot... I have some additional questions for you below, please forgive my ignorance :smile:

* tap to click (https://github.com/mate-desktop/mate-settings-daemon/commit/4e098ea0e6497444ada3aea67892ae92e00e90eb): when setting this property, libinput part of code doesn't take left-handed and 1/2/3 finger tap properties into account. While left-handed property isn't needed here (libinput manages it on its own), I'm not sure about finger tap ones. It wasn't an issue in Cinnamon since it seems to be MATE-only option (added in https://github.com/mate-desktop/mate-settings-daemon/pull/86). Should we do anything about 1/2/3 finger tap properties in libinput parts of code?

* edge and two-finger scrolling (https://github.com/mate-desktop/mate-settings-daemon/commit/c75315d6a5ed9a8171ff756c04c915e287e81151): libinput only allows either one to be enabled at the same time. Following the Cinnamon code, I've made two-finger one preferable. However, each property is set in its own boolean value in libinput (in ```libinput Scroll Method Enabled``` property), so could it be theoretically possible for libinput to support both at the same time in some future release?

* click actions (https://github.com/mate-desktop/mate-settings-daemon/commit/43bc83efe779afaa18c9a955f744822acc496c22): libinput doesn't support setting two or three finger click, there's only a single "clickfinger" setting (or no finger click if "buttonareas" is set instead). Since it's a single boolean value (in ```libinput Click Method Enabled``` property), I guess we have no way to tell libinput whether we prefer two or three finger click. So the question is, which of them will actually work when "clickfinger" is enabled in libinput?

* left-handed (https://github.com/mate-desktop/mate-settings-daemon/commit/2bc9262d0732e9ff886c079918618db07ef0821d): libinput part of code doesn't use button remapping as libinput handles that by itself. But does libinput check if a device has a single button (or any buttons at all)? In the old code, there are checks for that before making any changes.

* acceleration (https://github.com/mate-desktop/mate-settings-daemon/commit/f2b0f0c0a9068ee2bbd09fd7071d0abb963d56fe): libinput doesn't have a setting for a threshold. That setting is called "sensitivity" in mouse and touchpad properties UI, but it really is a "distance in pixels the pointer must move before accelerated mouse/touchpad motion is activated". So does libinput use some internal value for it?