### PR TITLE
Request keyboard event reports from global keybindings of other windows

### DIFF
--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -554,7 +554,9 @@ msd_keybindings_manager_start (MsdKeybindingsManager *manager,
                 gdk_window_add_filter (window,
                                        (GdkFilterFunc) keybindings_filter,
                                        manager);
+                gdk_error_trap_push ();
                 XSelectInput(GDK_DISPLAY_XDISPLAY(dpy), GDK_WINDOW_XID(window), KeyPressMask);
+                gdk_error_trap_pop_ignored ();
         }
         manager->priv->screens = get_screens_list ();
 

--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -538,6 +538,7 @@ msd_keybindings_manager_start (MsdKeybindingsManager *manager,
 {
         GdkDisplay  *dpy;
         GdkScreen   *screen;
+        GdkWindow   *window;
         int          screen_num;
         int          i;
 
@@ -549,9 +550,11 @@ msd_keybindings_manager_start (MsdKeybindingsManager *manager,
 
         for (i = 0; i < screen_num; i++) {
                 screen = gdk_display_get_screen (dpy, i);
-                gdk_window_add_filter (gdk_screen_get_root_window (screen),
+                window = gdk_screen_get_root_window(screen);
+                gdk_window_add_filter (window,
                                        (GdkFilterFunc) keybindings_filter,
                                        manager);
+                XSelectInput(GDK_DISPLAY_XDISPLAY(dpy), GDK_WINDOW_XID(window), KeyPressMask | KeyReleaseMask);
         }
         manager->priv->screens = get_screens_list ();
 

--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -554,7 +554,7 @@ msd_keybindings_manager_start (MsdKeybindingsManager *manager,
                 gdk_window_add_filter (window,
                                        (GdkFilterFunc) keybindings_filter,
                                        manager);
-                XSelectInput(GDK_DISPLAY_XDISPLAY(dpy), GDK_WINDOW_XID(window), KeyPressMask | KeyReleaseMask);
+                XSelectInput(GDK_DISPLAY_XDISPLAY(dpy), GDK_WINDOW_XID(window), KeyPressMask);
         }
         manager->priv->screens = get_screens_list ();
 


### PR DESCRIPTION
This allows mate-settings-daemon to honor global keybindings whenever
a different application has keybindings that seem conflicting, but are
usually not.

For example, an application defining a `Super_L` keybinding
and MATE having defining a shortcut that uses the `<Mod4>` key. They are
the same physical keyboard, but one is a modifier and the other is not.
Without requesting keyboard reports from other windows, the `<Mod4>`
shortcuts are swallowed whenever there is a `Super_L` shortcut
elsewhere.