### PR TITLE
touchpad: disable clickfinger by default

### DIFF
--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -46,12 +46,12 @@
       <description>Set this to TRUE to enable all touchpads.</description>
     </key>
     <key name="two-finger-click" type="i">
-      <default>3</default>
+      <default>0</default>
       <summary>Enabled two-finger button-click emulation</summary>
       <description>0 thru 3, 0 is inactive, 1-3 is button to emulate</description>
     </key>
     <key name="three-finger-click" type="i">
-      <default>2</default>
+      <default>0</default>
       <summary>Enable three-finger button-click emulation</summary>
       <description>0 thru 3, 0 is inactive, 1-3 is button to emulate</description>
     </key>


### PR DESCRIPTION
Now that libinput driver is handling the touchpad (instead of synaptics), I guess it's preferable to disable clickfinger (i.e.: multi-finger click emulation) by default, because libinput disables software buttons when clickfinger is used.

Software buttons seems a more intuitive input method for a brand new installed system...

See https://bugzilla.redhat.com/show_bug.cgi?id=1465115