### PR TITLE
msd-keyboard-xkb: Fix Gdk-CRITICAL warning on creating status bar icon

### DIFF
--- a/plugins/keyboard/msd-keyboard-xkb.c
+++ b/plugins/keyboard/msd-keyboard-xkb.c
@@ -340,7 +340,8 @@ show_hide_icon ()
 
 			xkl_debug (150, "Creating new icon\n");
 			icon = matekbd_status_new ();
-			gtk_status_icon_set_name (icon, "keyboard");
+                        /* commenting out fixes a Gdk-critical warning */
+/*			gtk_status_icon_set_name (icon, "keyboard");*/
 			g_signal_connect (icon, "popup-menu",
 					  G_CALLBACK
 					  (status_icon_popup_menu_cb),


### PR DESCRIPTION
Fixes that runtime warning in .xsession-errors if the applet is used.
```
Gdk-CRITICAL **: gdk_window_thaw_toplevel_updates: assertion
'window->update_and_descendants_freeze_count > 0' failed
```
inspired from:
https://git.xfce.org/apps/xfce4-terminal/commit/?id=eff5e2d

