### PR TITLE
avoid deprecated gdk_screen_get_width/height and gdk_screen_get_width/height_mm

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -177,11 +177,15 @@ get_dpi_from_x_server (void)
         if (screen != NULL) {
                 double width_dpi;
                 double height_dpi;
+                gint   sc_width;
+                gint   sc_height;
 
-                width_dpi = dpi_from_pixels_and_mm (gdk_screen_get_width (screen),
-                                                    gdk_screen_get_width_mm (screen));
-                height_dpi = dpi_from_pixels_and_mm (gdk_screen_get_height (screen),
-                                                     gdk_screen_get_height_mm (screen));
+                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                         &sc_width, &sc_height);
+
+                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
+                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
+
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE
                     || width_dpi > DPI_HIGH_REASONABLE_VALUE
                     || height_dpi < DPI_LOW_REASONABLE_VALUE

--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -179,12 +179,25 @@ get_dpi_from_x_server (void)
                 double height_dpi;
                 gint   sc_width;
                 gint   sc_height;
+#if GTK_CHECK_VERSION (3, 22, 0)
+                GdkDisplay *display;
+                GdkMonitor *monitor;
+
+
+                display = gdk_screen_get_display (screen);
+                monitor = gdk_display_get_primary_monitor (display);
+#endif
 
                 gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
                                          &sc_width, &sc_height);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_monitor_get_width_mm (monitor));
+                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_monitor_get_height_mm (monitor));
+#else
                 width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
                 height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
+#endif
 
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE
                     || width_dpi > DPI_HIGH_REASONABLE_VALUE

--- a/plugins/background/msd-background-manager.c
+++ b/plugins/background/msd-background-manager.c
@@ -183,10 +183,14 @@ static void
 real_draw_bg (MsdBackgroundManager *manager,
 	      GdkScreen		   *screen)
 {
+	gint width;
+	gint height;
+
 	MsdBackgroundManagerPrivate *p = manager->priv;
 	GdkWindow *window = gdk_screen_get_root_window (screen);
-	gint width   = gdk_screen_get_width (screen);
-	gint height  = gdk_screen_get_height (screen);
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &width, &height);
 
 	free_bg_surface (manager);
 	p->surface = mate_bg_create_surface (p->bg, window, width, height, TRUE);
@@ -254,15 +258,19 @@ static void
 on_screen_size_changed (GdkScreen            *screen,
 			MsdBackgroundManager *manager)
 {
+	gint sc_width, sc_height;
+
 	MsdBackgroundManagerPrivate *p = manager->priv;
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &sc_width, &sc_height);
 
 	if (!p->msd_can_draw || p->draw_in_progress || caja_is_drawing_bg (manager))
 		return;
 
 	gint scr_num = gdk_x11_screen_get_screen_number (screen);
 	gchar *old_size = g_list_nth_data (manager->priv->scr_sizes, scr_num);
-	gchar *new_size = g_strdup_printf ("%dx%d", gdk_screen_get_width (screen),
-						    gdk_screen_get_height (screen));
+	gchar *new_size = g_strdup_printf ("%dx%d", sc_width, sc_height);
 	if (g_strcmp0 (old_size, new_size) != 0)
 	{
 		g_debug ("Screen%d size changed: %s -> %s", scr_num, old_size, new_size);

--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -444,6 +444,7 @@ msd_osd_window_init (MsdOsdWindow *window)
 
         if (window->priv->is_composited) {
                 gdouble scalew, scaleh, scale;
+                gint sc_width, sc_height;
                 gint size;
 
                 gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
@@ -452,9 +453,12 @@ msd_osd_window_init (MsdOsdWindow *window)
                 GtkStyleContext *style = gtk_widget_get_style_context (GTK_WIDGET (window));
                 gtk_style_context_add_class (style, "window-frame");
 
+                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                         &sc_width, &sc_height);
+
                 /* assume 130x130 on a 640x480 display and scale from there */
-                scalew = gdk_screen_get_width (screen) / 640.0;
-                scaleh = gdk_screen_get_height (screen) / 480.0;
+                scalew = sc_width / 640.0;
+                scaleh = sc_height / 480.0;
                 scale = MIN (scalew, scaleh);
                 size = 130 * MAX (1, scale);
 

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -238,12 +238,24 @@ get_dpi_from_x_server (void)
         if (screen != NULL) {
                 double width_dpi, height_dpi;
                 gint   sc_width, sc_height;
+#if GTK_CHECK_VERSION (3, 22, 0)
+                GdkDisplay *display;
+                GdkMonitor *monitor;
+
+                display = gdk_screen_get_display (screen);
+                monitor = gdk_display_get_primary_monitor (display);
+#endif
 
                 gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
                                          &sc_width, &sc_height);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_monitor_get_width_mm (monitor));
+                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_monitor_get_height_mm (monitor));
+#else
                 width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
                 height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
+#endif
 
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE
                     || height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE) {

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -237,9 +237,13 @@ get_dpi_from_x_server (void)
         screen = gdk_screen_get_default ();
         if (screen != NULL) {
                 double width_dpi, height_dpi;
+                gint   sc_width, sc_height;
 
-                width_dpi = dpi_from_pixels_and_mm (gdk_screen_get_width (screen), gdk_screen_get_width_mm (screen));
-                height_dpi = dpi_from_pixels_and_mm (gdk_screen_get_height (screen), gdk_screen_get_height_mm (screen));
+                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+                                         &sc_width, &sc_height);
+
+                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
+                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
 
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE
                     || height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE) {


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_get_width/height_mm