### PR TITLE
Set 96 DPI default

### DIFF
--- a/data/org.mate.font-rendering.gschema.xml.in
+++ b/data/org.mate.font-rendering.gschema.xml.in
@@ -18,7 +18,7 @@
   </enum>
   <schema id="org.mate.font-rendering" path="/org/mate/desktop/font-rendering/">
     <key name="dpi" type="d">
-      <default>0.0</default>
+      <default>96</default>
       <summary>DPI</summary>
       <description>The resolution used for converting font sizes to pixel sizes,  in dots per inch.</description>
     </key>


### PR DESCRIPTION
Having a zero setting leaves xorg to set the dpi and it isn't good at it