### PR TITLE
Fix: big fonts by default with "org.mate.desktop.font-rendering.dpi"

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -29,6 +29,7 @@
 #include <glib/gi18n.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include <dbus/dbus-glib.h>
 
@@ -177,27 +178,11 @@ get_dpi_from_x_server (void)
         if (screen != NULL) {
                 double width_dpi;
                 double height_dpi;
-                gint   sc_width;
-                gint   sc_height;
-#if GTK_CHECK_VERSION (3, 22, 0)
-                GdkDisplay *display;
-                GdkMonitor *monitor;
 
+                Screen *xscreen = gdk_x11_screen_get_xscreen (screen);
 
-                display = gdk_screen_get_display (screen);
-                monitor = gdk_display_get_primary_monitor (display);
-#endif
-
-                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                         &sc_width, &sc_height);
-
-#if GTK_CHECK_VERSION (3, 22, 0)
-                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_monitor_get_width_mm (monitor));
-                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_monitor_get_height_mm (monitor));
-#else
-                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
-                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
-#endif
+                width_dpi = dpi_from_pixels_and_mm (WidthOfScreen (xscreen), WidthMMOfScreen (xscreen));
+                height_dpi = dpi_from_pixels_and_mm (HeightOfScreen (xscreen), HeightMMOfScreen (xscreen));
 
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE
                     || width_dpi > DPI_HIGH_REASONABLE_VALUE

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -237,25 +237,11 @@ get_dpi_from_x_server (void)
         screen = gdk_screen_get_default ();
         if (screen != NULL) {
                 double width_dpi, height_dpi;
-                gint   sc_width, sc_height;
-#if GTK_CHECK_VERSION (3, 22, 0)
-                GdkDisplay *display;
-                GdkMonitor *monitor;
 
-                display = gdk_screen_get_display (screen);
-                monitor = gdk_display_get_primary_monitor (display);
-#endif
+                Screen *xscreen = gdk_x11_screen_get_xscreen (screen);
 
-                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                         &sc_width, &sc_height);
-
-#if GTK_CHECK_VERSION (3, 22, 0)
-                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_monitor_get_width_mm (monitor));
-                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_monitor_get_height_mm (monitor));
-#else
-                width_dpi = dpi_from_pixels_and_mm (sc_width, gdk_screen_get_width_mm (screen));
-                height_dpi = dpi_from_pixels_and_mm (sc_height, gdk_screen_get_height_mm (screen));
-#endif
+                width_dpi = dpi_from_pixels_and_mm (WidthOfScreen (xscreen), WidthMMOfScreen (xscreen));
+                height_dpi = dpi_from_pixels_and_mm (HeightOfScreen (xscreen), HeightMMOfScreen (xscreen));
 
                 if (width_dpi < DPI_LOW_REASONABLE_VALUE || width_dpi > DPI_HIGH_REASONABLE_VALUE
                     || height_dpi < DPI_LOW_REASONABLE_VALUE || height_dpi > DPI_HIGH_REASONABLE_VALUE) {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1517547