### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/plugins/background/msd-background-manager.c
+++ b/plugins/background/msd-background-manager.c
@@ -183,14 +183,10 @@ static void
 real_draw_bg (MsdBackgroundManager *manager,
 	      GdkScreen		   *screen)
 {
-	gint width;
-	gint height;
-
 	MsdBackgroundManagerPrivate *p = manager->priv;
 	GdkWindow *window = gdk_screen_get_root_window (screen);
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &width, &height);
+	gint width   = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	gint height  = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 
 	free_bg_surface (manager);
 	p->surface = mate_bg_create_surface (p->bg, window, width, height, TRUE);
@@ -254,19 +250,15 @@ static void
 on_screen_size_changed (GdkScreen            *screen,
 			MsdBackgroundManager *manager)
 {
-	gint sc_width, sc_height;
-
 	MsdBackgroundManagerPrivate *p = manager->priv;
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &sc_width, &sc_height);
 
 	if (!p->msd_can_draw || p->draw_in_progress || caja_is_drawing_bg (manager))
 		return;
 
 	gint scr_num = gdk_x11_screen_get_screen_number (screen);
 	gchar *old_size = g_list_nth_data (manager->priv->scr_sizes, scr_num);
-	gchar *new_size = g_strdup_printf ("%dx%d", sc_width, sc_height);
+	gchar *new_size = g_strdup_printf ("%dx%d", WidthOfScreen (gdk_x11_screen_get_xscreen (screen)),
+						    HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
 	if (g_strcmp0 (old_size, new_size) != 0)
 	{
 		g_debug ("Screen%d size changed: %s -> %s", scr_num, old_size, new_size);

--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -35,6 +35,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "msd-osd-window.h"
 
@@ -444,7 +445,6 @@ msd_osd_window_init (MsdOsdWindow *window)
 
         if (window->priv->is_composited) {
                 gdouble scalew, scaleh, scale;
-                gint sc_width, sc_height;
                 gint size;
 
                 gtk_window_set_decorated (GTK_WINDOW (window), FALSE);
@@ -453,12 +453,9 @@ msd_osd_window_init (MsdOsdWindow *window)
                 GtkStyleContext *style = gtk_widget_get_style_context (GTK_WIDGET (window));
                 gtk_style_context_add_class (style, "window-frame");
 
-                gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                                         &sc_width, &sc_height);
-
                 /* assume 130x130 on a 640x480 display and scale from there */
-                scalew = sc_width / 640.0;
-                scaleh = sc_height / 480.0;
+                scalew = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / 640.0;
+                scaleh = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / 480.0;
                 scale = MIN (scalew, scaleh);
                 size = 130 * MAX (1, scale);
 


### PR DESCRIPTION
The work began with:

https://github.com/mate-desktop/mate-settings-daemon/commit/788babedafaf59d8b7a36cb0ef3b0b1f0e5f732c

This commit reverts:

https://github.com/mate-desktop/mate-settings-daemon/commit/7f887e614812ccb86f5d784e2db58bede8daa712

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height