### PR TITLE
Add support for HiDPI displays

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -173,6 +173,7 @@ get_dpi_from_x_server (void)
 {
         GdkScreen *screen;
         double     dpi;
+        int        scale;
 
         screen = gdk_screen_get_default ();
         if (screen != NULL) {
@@ -181,6 +182,7 @@ get_dpi_from_x_server (void)
 
                 Screen *xscreen = gdk_x11_screen_get_xscreen (screen);
 
+                scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
                 width_dpi = dpi_from_pixels_and_mm (WidthOfScreen (xscreen), WidthMMOfScreen (xscreen));
                 height_dpi = dpi_from_pixels_and_mm (HeightOfScreen (xscreen), HeightMMOfScreen (xscreen));
 
@@ -192,6 +194,9 @@ get_dpi_from_x_server (void)
                 } else {
                         dpi = (width_dpi + height_dpi) / 2.0;
                 }
+
+                dpi *= scale;
+
         } else {
                 /* Huh!?  No screen? */
                 dpi = DPI_DEFAULT;

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <math.h>
 #include <time.h>
 
 #include <X11/Xatom.h>
@@ -233,6 +234,7 @@ get_dpi_from_x_server (void)
 {
         GdkScreen *screen;
         double     dpi;
+        gint       scale;
 
         screen = gdk_screen_get_default ();
         if (screen != NULL) {
@@ -254,6 +256,11 @@ get_dpi_from_x_server (void)
 
                 dpi = DPI_FALLBACK;
         }
+
+
+        scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
+        if (scale)
+                dpi = ceil(dpi * scale);
 
         return dpi;
 }
@@ -307,7 +314,7 @@ xft_settings_get (MateXSettingsManager *manager,
         char      *hinting;
         char      *rgba_order;
         double     dpi;
-        int        scale;
+        gint       scale;
 
         mouse_gsettings = g_hash_table_lookup (manager->priv->gsettings, MOUSE_SCHEMA);
         screen = gdk_screen_get_default();
@@ -321,7 +328,7 @@ xft_settings_get (MateXSettingsManager *manager,
         settings->antialias = TRUE;
         settings->hinting = TRUE;
         settings->hintstyle = "hintslight";
-        settings->dpi = dpi * scale * 1024; /* Xft wants 1/1024ths of an inch */
+        settings->dpi = dpi * 1024; /* Xft wants 1/1024ths of an inch */
         settings->cursor_theme = g_settings_get_string (mouse_gsettings, CURSOR_THEME_KEY);
         settings->cursor_size = scale * g_settings_get_int (mouse_gsettings, CURSOR_SIZE_KEY);
         settings->rgba = "rgb";

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -302,24 +302,28 @@ xft_settings_get (MateXSettingsManager *manager,
                   MateXftSettings *settings)
 {
         GSettings *mouse_gsettings;
+        GdkScreen *screen;
         char      *antialiasing;
         char      *hinting;
         char      *rgba_order;
         double     dpi;
+        int        scale;
 
         mouse_gsettings = g_hash_table_lookup (manager->priv->gsettings, MOUSE_SCHEMA);
+        screen = gdk_screen_get_default();
 
         antialiasing = g_settings_get_string (manager->priv->gsettings_font, FONT_ANTIALIASING_KEY);
         hinting = g_settings_get_string (manager->priv->gsettings_font, FONT_HINTING_KEY);
         rgba_order = g_settings_get_string (manager->priv->gsettings_font, FONT_RGBA_ORDER_KEY);
         dpi = get_dpi_from_gsettings_or_x_server (manager->priv->gsettings_font);
+        scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
 
         settings->antialias = TRUE;
         settings->hinting = TRUE;
         settings->hintstyle = "hintslight";
-        settings->dpi = dpi * 1024; /* Xft wants 1/1024ths of an inch */
+        settings->dpi = dpi * scale * 1024; /* Xft wants 1/1024ths of an inch */
         settings->cursor_theme = g_settings_get_string (mouse_gsettings, CURSOR_THEME_KEY);
-        settings->cursor_size = g_settings_get_int (mouse_gsettings, CURSOR_SIZE_KEY);
+        settings->cursor_size = scale * g_settings_get_int (mouse_gsettings, CURSOR_SIZE_KEY);
         settings->rgba = "rgb";
 
         if (rgba_order) {

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
-#include <math.h>
 #include <time.h>
 
 #include <X11/Xatom.h>
@@ -260,7 +259,7 @@ get_dpi_from_x_server (void)
 
         scale = gdk_window_get_scale_factor (gdk_screen_get_root_window (screen));
         if (scale)
-                dpi = ceil(dpi * scale);
+                dpi = dpi * scale;
 
         return dpi;
 }


### PR DESCRIPTION
When setting `GDK_SCALE=2` and `GDK_DPI_SCALE=0.5` as env variables, m-s-d will now scale the mouse pointer and the font-rendering DPI.

This is part of multiple pull requests:
* mate-desktop/mate-settings-daemon/pull/208
* mate-desktop/mate-control-center/pull/325
* mate-desktop/mate-panel/pull/710
* ubuntu-mate/mate-hud/pull/18
* ubuntu-mate/mate-tweak/pull/37