### PR TITLE
Xrandr applet: fix popup menu

### DIFF
--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1693,6 +1693,9 @@ output_title_label_draw_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
         g_string_append (string, ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>label{\n");
         g_string_append (string, "color: black;");
         g_string_append (string, "padding-left: 4px; padding-right: 4px;");
+        g_string_append (string, "border-style: inset;");
+        g_string_append (string, "border-width: 1px;");
+        g_string_append (string, "border-color: gray;");
         g_string_append (string, "background-color:");
         g_string_append (string, color_string);
         g_string_append (string," }");
@@ -1774,6 +1777,7 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
             ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>image{\n"
              "opacity: 1.0; \n"
              "-gtk-icon-effect: none; \n"
+             "min-height: 36px; \n" /*Use as a spacer so label border does not put scrollbars on popup*/
              "}",
              -1, NULL);
 	    gtk_style_context_add_provider (context,

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1689,12 +1689,11 @@ output_title_label_draw_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
 
         color_string = gdk_rgba_to_string (&color);
 
+        /*This can be overriden by themes, check all label:insensitive entries if it does not show up*/
         string = g_string_new(NULL);
         g_string_append (string, ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>label{\n");
-        g_string_append (string, "color: black;");
+        /* g_string_append (string, "color: black;"); Does not work-overridden in all themes*/
         g_string_append (string, "padding-left: 4px; padding-right: 4px;");
-        g_string_append (string, "border-style: inset;");
-        g_string_append (string, "border-width: 1px;");
         g_string_append (string, "border-color: gray;");
         g_string_append (string, "background-color:");
         g_string_append (string, color_string);
@@ -1708,7 +1707,7 @@ output_title_label_draw_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
 
 	    gtk_style_context_add_provider (context,
 					GTK_STYLE_PROVIDER (provider),
-					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+					GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
 	    g_object_unref (provider);
 
         return FALSE;
@@ -1770,21 +1769,32 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         context = gtk_widget_get_style_context (item);
         gtk_style_context_add_class (context, "xrandr-applet");
 
-        /*Disable effects applied to icons in an insensitive menu item*/
-        context = gtk_widget_get_style_context (image);
+        /*This is NOT overrridden by themes as FALLBACK won't work here
+         *
+         *Disable dim/opacity effects applied to icons in an insensitive menu item
+         *And apply the final label border width and style here
+         *(style required too because "none" will define zero width)
+         *before the draw call so label width is defined here
+         *Draw call is too late and will cause scrollbars to appear from
+         *delayed expansion of the label
+         */
+
         provider = gtk_css_provider_new ();
         gtk_css_provider_load_from_data (provider,
             ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>image{\n"
              "opacity: 1.0; \n"
              "-gtk-icon-effect: none; \n"
-             "min-height: 36px; \n" /*Use as a spacer so label border does not put scrollbars on popup*/
+             "}"
+             ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>label{\n"
+             "border-width: 1px;"
+             "border-style: inset;"
              "}",
              -1, NULL);
-	    gtk_style_context_add_provider (context,
+        /*Need to handle both the image and the label, so has to be for screen to work*/
+        gtk_style_context_add_provider_for_screen (gdk_screen_get_default(),
 					GTK_STYLE_PROVIDER (provider),
 					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 	    g_object_unref (provider);
-
 
         g_signal_connect (item, "size-allocate",
                           G_CALLBACK (title_item_size_allocate_cb), NULL);

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1714,11 +1714,14 @@ title_item_size_allocate_cb (GtkWidget *widget, GtkAllocation *allocation, gpoin
 static GtkWidget *
 make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *output)
 {
-        GtkWidget *item;
-        GtkWidget *label;
+        GtkWidget       *item;
+        GtkStyleContext *context;
+        GtkWidget       *label;
         char *str;
 
         item = gtk_menu_item_new ();
+        context = gtk_widget_get_style_context (item);
+        gtk_style_context_add_class (context, "xrandr-applet");
 
         g_signal_connect (item, "size-allocate",
                           G_CALLBACK (title_item_size_allocate_cb), NULL);

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1671,6 +1671,45 @@ status_icon_popup_menu_selection_done_cb (GtkMenuShell *menu_shell, gpointer dat
 
 #define OUTPUT_TITLE_ITEM_BORDER 2
 #define OUTPUT_TITLE_ITEM_PADDING 4
+static gboolean
+output_title_label_draw_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
+{
+        MsdXrandrManager *manager = MSD_XRANDR_MANAGER (data);
+        struct MsdXrandrManagerPrivate *priv = manager->priv;
+        MateRROutputInfo *output;
+        GdkRGBA color;
+        GString *string;
+        gchar *css, *color_string;
+        GtkStyleContext *context;
+        GtkCssProvider  *provider;
+
+        output = g_object_get_data (G_OBJECT (widget), "output");
+
+        mate_rr_labeler_get_rgba_for_output (priv->labeler, output, &color);
+
+        color_string = gdk_rgba_to_string (&color);
+
+        string = g_string_new(NULL);
+        g_string_append (string, ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>label{\n");
+        g_string_append (string, "color: black;");
+        g_string_append (string, "padding-left: 4px; padding-right: 4px;");
+        g_string_append (string, "background-color:");
+        g_string_append (string, color_string);
+        g_string_append (string," }");
+
+        css = g_string_free (string, FALSE);
+
+        context = gtk_widget_get_style_context (widget);
+        provider = gtk_css_provider_new ();
+        gtk_css_provider_load_from_data (provider,css, -1, NULL);
+
+	    gtk_style_context_add_provider (context,
+					GTK_STYLE_PROVIDER (provider),
+					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	    g_object_unref (provider);
+
+        return FALSE;
+}
 
 static void
 title_item_size_allocate_cb (GtkWidget *widget, GtkAllocation *allocation, gpointer data)
@@ -1716,6 +1755,7 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
 {
         GtkWidget       *item;
         GtkStyleContext *context;
+        GtkCssProvider  *provider;
         GtkWidget       *label;
         GtkWidget       *image;
         GtkWidget *box;
@@ -1723,9 +1763,24 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
 
         item = gtk_menu_item_new ();
         box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
-        image = gtk_image_new_from_icon_name ("computer-symbolic", GTK_ICON_SIZE_MENU);
+        image = gtk_image_new_from_icon_name ("computer", GTK_ICON_SIZE_MENU);
         context = gtk_widget_get_style_context (item);
         gtk_style_context_add_class (context, "xrandr-applet");
+
+        /*Disable effects applied to icons in an insensitive menu item*/
+        context = gtk_widget_get_style_context (image);
+        provider = gtk_css_provider_new ();
+        gtk_css_provider_load_from_data (provider,
+            ".mate-panel-menu-bar menuitem.xrandr-applet:disabled>box>image{\n"
+             "opacity: 1.0; \n"
+             "-gtk-icon-effect: none; \n"
+             "}",
+             -1, NULL);
+	    gtk_style_context_add_provider (context,
+					GTK_STYLE_PROVIDER (provider),
+					GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	    g_object_unref (provider);
+
 
         g_signal_connect (item, "size-allocate",
                           G_CALLBACK (title_item_size_allocate_cb), NULL);
@@ -1747,7 +1802,13 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         gtk_container_add (GTK_CONTAINER (box), label);
         gtk_container_add (GTK_CONTAINER (item), box);
 
+        g_signal_connect (label, "draw",
+                          G_CALLBACK (output_title_label_draw_cb), manager);
+
+        g_object_set_data (G_OBJECT (label), "output", output);
+
         gtk_widget_set_sensitive (item, FALSE); /* the title is not selectable */
+
         gtk_widget_show_all (item);
 
         return item;

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1717,9 +1717,13 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         GtkWidget       *item;
         GtkStyleContext *context;
         GtkWidget       *label;
+        GtkWidget       *image;
+        GtkWidget *box;
         char *str;
 
         item = gtk_menu_item_new ();
+        box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+        image = gtk_image_new_from_icon_name ("computer-symbolic", GTK_ICON_SIZE_MENU);
         context = gtk_widget_get_style_context (item);
         gtk_style_context_add_class (context, "xrandr-applet");
 
@@ -1739,7 +1743,9 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         gtk_widget_set_margin_top (label, OUTPUT_TITLE_ITEM_BORDER + OUTPUT_TITLE_ITEM_PADDING);
         gtk_widget_set_margin_bottom (label, OUTPUT_TITLE_ITEM_BORDER + OUTPUT_TITLE_ITEM_PADDING);
 
-        gtk_container_add (GTK_CONTAINER (item), label);
+        gtk_container_add (GTK_CONTAINER (box), image);
+        gtk_container_add (GTK_CONTAINER (box), label);
+        gtk_container_add (GTK_CONTAINER (item), box);
 
         gtk_widget_set_sensitive (item, FALSE); /* the title is not selectable */
         gtk_widget_show_all (item);

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -1787,7 +1787,6 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         GtkWidget *item;
         GtkWidget *label;
         char *str;
-        GdkColor black = { 0, 0, 0, 0 };
 
         item = gtk_menu_item_new ();
 
@@ -1798,12 +1797,6 @@ make_menu_item_for_output_title (MsdXrandrManager *manager, MateRROutputInfo *ou
         label = gtk_label_new (NULL);
         gtk_label_set_markup (GTK_LABEL (label), str);
         g_free (str);
-
-        /* Make the label explicitly black.  We don't want it to follow the
-         * theme's colors, since the label is always shown against a light
-         * pastel background.  See bgo#556050
-         */
-        gtk_widget_modify_fg (label, gtk_widget_get_state (label), &black);
 
         /* Add padding around the label to fit the box that we'll draw for color-coding */
         gtk_label_set_xalign (GTK_LABEL (label), 0.0);


### PR DESCRIPTION
before
![xrandr-applet-menu-before](https://user-images.githubusercontent.com/961604/39722981-9d523032-5244-11e8-9074-8edc6902749a.jpg)

after
![xrandr-applet-menu-after](https://user-images.githubusercontent.com/961604/39722992-a5b110f4-5244-11e8-8df4-e290323ae537.jpg)

