### PR TITLE
media-keys: Add support for XF86TouchpadOn/Off

### DIFF
--- a/plugins/media-keys/acme.h
+++ b/plugins/media-keys/acme.h
@@ -27,6 +27,8 @@
 
 enum {
         TOUCHPAD_KEY,
+        TOUCHPAD_ON_KEY,
+        TOUCHPAD_OFF_KEY,
         MUTE_KEY,
         VOLUME_DOWN_KEY,
         VOLUME_UP_KEY,
@@ -63,6 +65,8 @@ static struct {
         Key *key;
 } keys[HANDLED_KEYS] = {
         { TOUCHPAD_KEY, "touchpad", NULL, NULL },
+        { TOUCHPAD_ON_KEY, NULL, "XF86TouchpadOn", NULL },
+        { TOUCHPAD_OFF_KEY, NULL, "XF86TouchpadOff", NULL },
         { MUTE_KEY, "volume-mute", NULL, NULL },
         { VOLUME_DOWN_KEY, "volume-down", NULL, NULL },
         { VOLUME_UP_KEY, "volume-up", NULL, NULL },

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -586,6 +586,15 @@ do_eject_action (MsdMediaKeysManager *manager)
 }
 
 static void
+do_touchpad_osd_action (MsdMediaKeysManager *manager, gboolean state)
+{
+        dialog_init (manager);
+        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                 state ? "touchpad-enabled" : "touchpad-disabled",
+                                                 FALSE);
+        dialog_show (manager);
+}
+static void
 do_touchpad_action (MsdMediaKeysManager *manager)
 {
         GSettings *settings = g_settings_new (TOUCHPAD_SCHEMA);
@@ -929,6 +938,12 @@ do_action (MsdMediaKeysManager *manager,
         switch (type) {
         case TOUCHPAD_KEY:
                 do_touchpad_action (manager);
+                break;
+        case TOUCHPAD_ON_KEY:
+                do_touchpad_osd_action(manager, TRUE);
+                break;
+        case TOUCHPAD_OFF_KEY:
+                do_touchpad_osd_action(manager, FALSE);
                 break;
         case MUTE_KEY:
         case VOLUME_DOWN_KEY:


### PR DESCRIPTION
Using hard-coded keys.

This requires new keycodes added to X.org in:
https://bugs.freedesktop.org/show_bug.cgi?id=31300

Ported from gnome-settings-daemon:
https://github.com/GNOME/gnome-settings-daemon/commit/1c8f64d1dc6beb7d27a6dce74fa29e27e8c34583