### PR TITLE
media-keys: Simplify touchpad OSD

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -601,17 +601,11 @@ do_touchpad_action (MsdMediaKeysManager *manager)
         gboolean state = g_settings_get_boolean (settings, TOUCHPAD_ENABLED_KEY);
 
         if (touchpad_is_present () == FALSE) {
-                dialog_init (manager);
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                         "touchpad-disabled", FALSE);
+                do_touchpad_osd_action (manager, FALSE);
                 return;
         }
 
-        dialog_init (manager);
-        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 (!state) ? "touchpad-enabled" : "touchpad-disabled",
-                                                 FALSE);
-        dialog_show (manager);
+        do_touchpad_osd_action (manager, !state);
 
         g_settings_set_boolean (settings, TOUCHPAD_ENABLED_KEY, !state);
         g_object_unref (settings);


### PR DESCRIPTION
This PR is ported from gnome-settings-daemon:
https://github.com/GNOME/gnome-settings-daemon/commit/fe41be4f980dee86a594105398a63cb3e1b4c689