### PR TITLE
Remove unuseful argument and test for screen brightness OSD icons

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -581,8 +581,7 @@ do_eject_action (MsdMediaKeysManager *manager)
         /* Show the dialogue */
         dialog_init (manager);
         msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 "media-eject",
-                                                 FALSE);
+                                                 "media-eject");
         dialog_show (manager);
 
         /* Clean up the drive selection and exit if no suitable
@@ -607,8 +606,7 @@ do_touchpad_osd_action (MsdMediaKeysManager *manager, gboolean state)
 {
         dialog_init (manager);
         msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 state ? "input-touchpad" : "touchpad-disabled",
-                                                 FALSE);
+                                                 state ? "input-touchpad" : "touchpad-disabled");
         dialog_show (manager);
 }
 
@@ -849,13 +847,11 @@ set_rfkill_complete (GObject      *object,
         if (data->bluetooth)
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
                                                          data->target_state ? "bluetooth-disabled-symbolic"
-                                                         : "bluetooth-active-symbolic",
-                                                        FALSE);
+                                                         : "bluetooth-active-symbolic");
         else
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
                                                         data->target_state ? "airplane-mode-symbolic"
-                                                        : "network-wireless-signal-excellent-symbolic",
-                                                        FALSE);
+                                                        : "network-wireless-signal-excellent-symbolic");
         dialog_show (data->manager);
 out:
         g_free (data->property);
@@ -884,8 +880,7 @@ do_rfkill_action (MsdMediaKeysManager *manager,
 
         if (get_rfkill_property (manager, hw_mode)) {
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                        "airplane-mode-symbolic",
-                                                        FALSE);
+                                                        "airplane-mode-symbolic");
                 dialog_show (manager);
                 return;
         }

--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -38,7 +38,6 @@ struct MsdMediaKeysWindowPrivate
 {
         MsdMediaKeysWindowAction action;
         char                    *icon_name;
-        gboolean                 show_level;
 
         guint                    volume_muted : 1;
         int                      volume_level;
@@ -90,7 +89,7 @@ action_changed (MsdMediaKeysWindow *window)
 
                         break;
                 case MSD_MEDIA_KEYS_WINDOW_ACTION_CUSTOM:
-                        volume_controls_set_visible (window, window->priv->show_level);
+                        volume_controls_set_visible (window, FALSE);
                         window_set_icon_name (window, window->priv->icon_name);
                         break;
                 default:
@@ -148,19 +147,16 @@ msd_media_keys_window_set_action (MsdMediaKeysWindow      *window,
 
 void
 msd_media_keys_window_set_action_custom (MsdMediaKeysWindow      *window,
-                                         const char              *icon_name,
-                                         gboolean                 show_level)
+                                         const char              *icon_name)
 {
         g_return_if_fail (MSD_IS_MEDIA_KEYS_WINDOW (window));
         g_return_if_fail (icon_name != NULL);
 
         if (window->priv->action != MSD_MEDIA_KEYS_WINDOW_ACTION_CUSTOM ||
-            g_strcmp0 (window->priv->icon_name, icon_name) != 0 ||
-            window->priv->show_level != show_level) {
+            g_strcmp0 (window->priv->icon_name, icon_name) != 0) {
                 window->priv->action = MSD_MEDIA_KEYS_WINDOW_ACTION_CUSTOM;
                 g_free (window->priv->icon_name);
                 window->priv->icon_name = g_strdup (icon_name);
-                window->priv->show_level = show_level;
                 action_changed (window);
         } else {
                 msd_osd_window_update_and_hide (MSD_OSD_WINDOW (window));
@@ -578,23 +574,15 @@ draw_action_custom (MsdMediaKeysWindow *window,
         double icon_box_height;
         double icon_box_x0;
         double icon_box_y0;
-        double bright_box_x0;
-        double bright_box_y0;
-        double bright_box_width;
-        double bright_box_height;
         gboolean res;
 
         gtk_window_get_size (GTK_WINDOW (window), &window_width, &window_height);
 
         icon_box_width = round (window_width * 0.65);
         icon_box_height = round (window_height * 0.65);
-        bright_box_width = round (icon_box_width);
-        bright_box_height = round (window_height * 0.05);
 
         icon_box_x0 = (window_width - icon_box_width) / 2;
-        icon_box_y0 = (window_height - icon_box_height - bright_box_height) / 2;
-        bright_box_x0 = round (icon_box_x0);
-        bright_box_y0 = round (icon_box_height + icon_box_y0);
+        icon_box_y0 = (window_height - icon_box_height) / 2;
 
 #if 0
         g_message ("icon box: w=%f h=%f _x0=%f _y0=%f",
@@ -602,11 +590,6 @@ draw_action_custom (MsdMediaKeysWindow *window,
                    icon_box_height,
                    icon_box_x0,
                    icon_box_y0);
-        g_message ("brightness box: w=%f h=%f _x0=%f _y0=%f",
-                   bright_box_width,
-                   bright_box_height,
-                   bright_box_x0,
-                   bright_box_y0);
 #endif
 
         res = render_custom (window,
@@ -618,17 +601,6 @@ draw_action_custom (MsdMediaKeysWindow *window,
                 draw_eject (cr,
                             icon_box_x0, icon_box_y0,
                             icon_box_width, icon_box_height);
-        }
-
-        if (window->priv->show_level != FALSE) {
-                /* draw volume meter */
-                draw_volume_boxes (window,
-                                   cr,
-                                   (double)window->priv->volume_level / 100.0,
-                                   bright_box_x0,
-                                   bright_box_y0,
-                                   bright_box_width,
-                                   bright_box_height);
         }
 }
 

--- a/plugins/media-keys/msd-media-keys-window.h
+++ b/plugins/media-keys/msd-media-keys-window.h
@@ -63,8 +63,7 @@ GtkWidget *           msd_media_keys_window_new               (void);
 void                  msd_media_keys_window_set_action        (MsdMediaKeysWindow      *window,
                                                                MsdMediaKeysWindowAction action);
 void                  msd_media_keys_window_set_action_custom (MsdMediaKeysWindow      *window,
-                                                               const char              *icon_name,
-                                                               gboolean                 show_level);
+                                                               const char              *icon_name);
 void                  msd_media_keys_window_set_volume_muted  (MsdMediaKeysWindow      *window,
                                                                gboolean                 muted);
 void                  msd_media_keys_window_set_volume_level  (MsdMediaKeysWindow      *window,

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -63,22 +63,19 @@ update_state (GtkWidget *window)
                 break;
         case 4:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "media-eject",
-                                                         FALSE);
+                                                         "media-eject");
 
                 gtk_widget_show (window);
                 break;
 	case 5:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "touchpad-disabled",
-                                                         FALSE);
+                                                         "touchpad-disabled");
 
                 gtk_widget_show (window);
                 break;
         case 6:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "input-touchpad",
-                                                          FALSE);
+                                                         "input-touchpad");
 
                 gtk_widget_show (window);
                 break;

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -68,41 +68,14 @@ update_state (GtkWidget *window)
 
                 gtk_widget_show (window);
                 break;
-        case 5:
-                msd_media_keys_window_set_volume_level (MSD_MEDIA_KEYS_WINDOW (window),
-                                                        0);
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "gpm-brightness-lcd",
-                                                         TRUE);
-
-                gtk_widget_show (window);
-                break;
-        case 6:
-                msd_media_keys_window_set_volume_level (MSD_MEDIA_KEYS_WINDOW (window),
-                                                        50);
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "gpm-brightness-lcd",
-                                                         TRUE);
-
-                gtk_widget_show (window);
-                break;
-        case 7:
-                msd_media_keys_window_set_volume_level (MSD_MEDIA_KEYS_WINDOW (window),
-                                                        100);
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "gpm-brightness-lcd",
-                                                         TRUE);
-
-                gtk_widget_show (window);
-                break;
-	case 8:
+	case 5:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
                                                          "touchpad-disabled",
                                                          FALSE);
 
                 gtk_widget_show (window);
                 break;
-        case 9:
+        case 6:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
                                                          "input-touchpad",
                                                           FALSE);
@@ -154,9 +127,6 @@ main (int    argc,
                 g_error_free (error);
                 exit (1);
         }
-
-        gtk_icon_theme_append_search_path (gtk_icon_theme_get_default (),
-                                           DATADIR G_DIR_SEPARATOR_S "mate-power-manager" G_DIR_SEPARATOR_S "icons");
 
         test_window ();
 


### PR DESCRIPTION
Screen brightness OSD has been moved from m-s-d to m-p-m, see:
https://github.com/mate-desktop/mate-power-manager/commit/4fd2ae34e50e63ef562356f804dbdea81341f4e2
So remove test for brightness OSD icons in m-s-d.

Sence brightness OSD has been moved to m-p-m, there is no any situation to control show_level in msd_media_keys_window_set_action_custom, should remove this argument.