### PR TITLE
media-keys: Add labels for the rfkill and touchpad OSD, and test for rfkill OSD icons 

### DIFF
--- a/plugins/media-keys/acme.ui
+++ b/plugins/media-keys/acme.ui
@@ -18,13 +18,23 @@
           </packing>
         </child>
         <child>
+          <object class="GtkLabel" id="acme_label">
+            <property name="visible">True</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkProgressBar" id="acme_volume_progressbar">
             <property name="visible">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -608,7 +608,7 @@ do_touchpad_osd_action (MsdMediaKeysManager *manager, gboolean state)
         dialog_init (manager);
         msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
                                                  state ? "input-touchpad" : "touchpad-disabled",
-                                                 NULL);
+                                                 state ? _("Touchpad enabled") : _("Touchpad disabled"));
         dialog_show (manager);
 }
 

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -581,7 +581,8 @@ do_eject_action (MsdMediaKeysManager *manager)
         /* Show the dialogue */
         dialog_init (manager);
         msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 "media-eject");
+                                                 "media-eject",
+                                                 NULL);
         dialog_show (manager);
 
         /* Clean up the drive selection and exit if no suitable
@@ -606,7 +607,8 @@ do_touchpad_osd_action (MsdMediaKeysManager *manager, gboolean state)
 {
         dialog_init (manager);
         msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                 state ? "input-touchpad" : "touchpad-disabled");
+                                                 state ? "input-touchpad" : "touchpad-disabled",
+                                                 NULL);
         dialog_show (manager);
 }
 
@@ -844,14 +846,21 @@ set_rfkill_complete (GObject      *object,
         g_debug ("Finished changing rfkill, property %s is now %s",
                  data->property, data->target_state ? "true" : "false");
 
-        if (data->bluetooth)
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
-                                                         data->target_state ? "bluetooth-disabled-symbolic"
-                                                         : "bluetooth-active-symbolic");
-        else
-                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
-                                                        data->target_state ? "airplane-mode-symbolic"
-                                                        : "network-wireless-signal-excellent-symbolic");
+        if (data->bluetooth){
+                if (data->target_state)
+                        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
+                                                                 "bluetooth-disabled-symbolic", _("Bluetooth disabled"));
+                else
+                        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
+                                                                 "bluetooth-active-symbolic", _("Bluetooth enabled"));
+        } else {
+                if (data->target_state)
+                        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
+                                                                 "airplane-mode-symbolic", _("Airplane mode enabled"));
+                else
+                        msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (data->manager->priv->dialog),
+                                                                 "network-wireless-signal-excellent-symbolic", _("Airplane mode disabled"));
+        }
         dialog_show (data->manager);
 out:
         g_free (data->property);
@@ -880,7 +889,8 @@ do_rfkill_action (MsdMediaKeysManager *manager,
 
         if (get_rfkill_property (manager, hw_mode)) {
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
-                                                        "airplane-mode-symbolic");
+                                                        "airplane-mode-symbolic",
+                                                        _("Hardware Airplane Mode"));
                 dialog_show (manager);
                 return;
         }

--- a/plugins/media-keys/msd-media-keys-window.h
+++ b/plugins/media-keys/msd-media-keys-window.h
@@ -63,7 +63,8 @@ GtkWidget *           msd_media_keys_window_new               (void);
 void                  msd_media_keys_window_set_action        (MsdMediaKeysWindow      *window,
                                                                MsdMediaKeysWindowAction action);
 void                  msd_media_keys_window_set_action_custom (MsdMediaKeysWindow      *window,
-                                                               const char              *icon_name);
+                                                               const char              *icon_name,
+                                                               const char              *description);
 void                  msd_media_keys_window_set_volume_muted  (MsdMediaKeysWindow      *window,
                                                                gboolean                 muted);
 void                  msd_media_keys_window_set_volume_level  (MsdMediaKeysWindow      *window,

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -71,14 +71,14 @@ update_state (GtkWidget *window)
 	case 5:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
                                                          "touchpad-disabled",
-                                                         NULL);
+                                                         _("Touchpad disabled"));
 
                 gtk_widget_show (window);
                 break;
         case 6:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
                                                          "input-touchpad",
-                                                         NULL);
+                                                         _("Touchpad enabled"));
 
                 gtk_widget_show (window);
                 break;

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -63,19 +63,22 @@ update_state (GtkWidget *window)
                 break;
         case 4:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "media-eject");
+                                                         "media-eject",
+                                                         NULL);
 
                 gtk_widget_show (window);
                 break;
 	case 5:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "touchpad-disabled");
+                                                         "touchpad-disabled",
+                                                         NULL);
 
                 gtk_widget_show (window);
                 break;
         case 6:
                 msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
-                                                         "input-touchpad");
+                                                         "input-touchpad",
+                                                         NULL);
 
                 gtk_widget_show (window);
                 break;

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -82,6 +82,34 @@ update_state (GtkWidget *window)
 
                 gtk_widget_show (window);
                 break;
+	case 7:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "bluetooth-disabled-symbolic",
+                                                         _("Bluetooth disabled"));
+
+                gtk_widget_show (window);
+                break;
+        case 8:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "bluetooth-active-symbolic",
+                                                         _("Bluetooth enabled"));
+
+                gtk_widget_show (window);
+                break;
+        case 9:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "airplane-mode-symbolic",
+                                                         _("Airplane mode enabled"));
+
+                gtk_widget_show (window);
+                break;
+        case 10:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "network-wireless-signal-excellent-symbolic",
+                                                         _("Airplane mode disabled"));
+
+                gtk_widget_show (window);
+                break;
         default:
                 gtk_main_quit ();
                 break;


### PR DESCRIPTION
Add labels for the rfkill and touchpad OSD, which should hopefully make the icons a bit clearer. Add test for rfkill OSD icons too.

![screenshot at 2018-11-11 04-30-20](https://user-images.githubusercontent.com/33945019/48311259-19af9980-e56b-11e8-85d2-117b2fe4678c.png)
