### PR TITLE
msd-xrdb-manager.c: avoid deprecated 'gtk_widget_ensure_style'

### DIFF
--- a/plugins/xrdb/msd-xrdb-manager.c
+++ b/plugins/xrdb/msd-xrdb-manager.c
@@ -500,7 +500,6 @@ msd_xrdb_manager_start (MsdXrdbManager *manager,
                           manager);
 
         manager->priv->widget = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-        gtk_widget_ensure_style (manager->priv->widget);
 
         mate_settings_profile_end (NULL);
 


### PR DESCRIPTION
Seems `gtk_widget_ensure_style` is useless, according to the documentation:

https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-ensure-style

> Not a very useful function; most of the time, if you want the style, the widget is realized, and realized widgets are guaranteed to have a style already.