### PR TITLE
media-keys: Don't show a level when muted

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -636,6 +636,9 @@ update_dialog (MsdMediaKeysManager *manager,
                gboolean             muted,
                gboolean             sound_changed)
 {
+        if (muted)
+                volume = 0.0;
+
         dialog_init (manager);
 
         msd_media_keys_window_set_volume_muted (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),


### PR DESCRIPTION
As discussed in:
https://bugzilla.gnome.org/show_bug.cgi?id=644537#c4
