### PR TITLE
media-keys: Add support for display switch OSD

### DIFF
--- a/plugins/media-keys/acme.h
+++ b/plugins/media-keys/acme.h
@@ -58,6 +58,7 @@ enum {
         LOGOUT_KEY,
         RFKILL_KEY,
         BLUETOOTH_RFKILL_KEY,
+        DISPLAY_KEY,
         HANDLED_KEYS,
 };
 
@@ -99,7 +100,8 @@ static struct {
         { ON_SCREEN_KEYBOARD_KEY, "on-screen-keyboard", NULL, NULL },
         { LOGOUT_KEY, "logout", NULL, NULL },
         { RFKILL_KEY, NULL, "XF86WLAN", NULL },
-        { BLUETOOTH_RFKILL_KEY, NULL, "XF86Bluetooth", NULL }
+        { BLUETOOTH_RFKILL_KEY, NULL, "XF86Bluetooth", NULL },
+        { DISPLAY_KEY, NULL, "XF86Display", NULL }
 };
 
 #endif /* __ACME_H__ */

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -918,6 +918,27 @@ do_rfkill_action (MsdMediaKeysManager *manager,
                  data->property, new_state ? "true" : "false");
 }
 
+static void
+do_display_osd_action (MsdMediaKeysManager *manager)
+{
+        GdkDisplay *display;
+        int         n_monitors;
+
+        display = gdk_display_get_default ();
+        n_monitors = gdk_display_get_n_monitors (display);
+
+        dialog_init (manager);
+        if (n_monitors > 1)
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                         "video-joined-displays-symbolic",
+                                                         _("Changing Screen Layout"));
+        else
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (manager->priv->dialog),
+                                                         "video-single-display-symbolic",
+                                                         _("No External Display"));
+        dialog_show (manager);
+}
+
 static gint
 find_by_application (gconstpointer a,
                      gconstpointer b)
@@ -1178,6 +1199,9 @@ do_action (MsdMediaKeysManager *manager,
                 break;
         case BLUETOOTH_RFKILL_KEY:
                 do_rfkill_action (manager, TRUE);
+                break;
+        case DISPLAY_KEY:
+                do_display_osd_action (manager);
                 break;
         default:
                 g_assert_not_reached ();

--- a/plugins/media-keys/test-media-window.c
+++ b/plugins/media-keys/test-media-window.c
@@ -110,6 +110,20 @@ update_state (GtkWidget *window)
 
                 gtk_widget_show (window);
                 break;
+        case 11:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "video-single-display-symbolic",
+                                                         _("No External Display"));
+
+                gtk_widget_show (window);
+                break;
+        case 12:
+                msd_media_keys_window_set_action_custom (MSD_MEDIA_KEYS_WINDOW (window),
+                                                         "video-joined-displays-symbolic",
+                                                         _("Changing Screen Layout"));
+
+                gtk_widget_show (window);
+                break;
         default:
                 gtk_main_quit ();
                 break;


### PR DESCRIPTION
Some laptops like thinkpad have a display switch mode hotkey. This is bound by default to XF86Display. Add OSD to give people a visual feed back to switch display mode.

The hotkey is like this:
![img_4043](https://user-images.githubusercontent.com/33945019/48926253-2e931200-ef07-11e8-89a0-3478122bbd1a.JPG)

looking the OSD bellow:
![screenshot at 2018-11-21 06-25-04](https://user-images.githubusercontent.com/33945019/48926255-2f2ba880-ef07-11e8-8ca2-3e9d9b548eed.png)
![screenshot at 2018-11-21 06-25-30](https://user-images.githubusercontent.com/33945019/48926257-2f2ba880-ef07-11e8-9cf5-76156912b510.png)

How to test:
Press the F7 hotkey on thinkpad with connecting more than one screen. Or execute:
```php
xdotool key XF86Display
```