### PR TITLE
Tweak the OSD a bit smaller

### DIFF
--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -457,11 +457,11 @@ msd_osd_window_init (MsdOsdWindow *window)
                 GtkStyleContext *style = gtk_widget_get_style_context (GTK_WIDGET (window));
                 gtk_style_context_add_class (style, "window-frame");
 
-                /* assume 130x130 on a 640x480 display and scale from there */
+                /* assume 110x110 on a 640x480 display and scale from there */
                 scalew = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) / (640.0 * window->priv->scale_factor);
                 scaleh = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / (480.0 * window->priv->scale_factor);
                 scale = MIN (scalew, scaleh);
-                size = 130 * MAX (1, scale);
+                size = 110 * MAX (1, scale);
 
                 gtk_window_set_default_size (GTK_WINDOW (window), size, size);
 

--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -489,8 +489,8 @@ draw_action_volume (MsdMediaKeysWindow *window,
         volume_box_width = icon_box_width;
         volume_box_height = round (window_height * 0.05);
 
-        icon_box_x0 = (window_width - icon_box_width) / 2;
-        icon_box_y0 = (window_height - icon_box_height) / 2;
+        icon_box_x0 = round ((window_width - icon_box_width) / 2);
+        icon_box_y0 = round ((window_height - icon_box_height) / 2);
         volume_box_x0 = round (icon_box_x0);
         volume_box_y0 = round (window_height - icon_box_y0 / 2 - volume_box_height);
 
@@ -625,8 +625,8 @@ draw_action_custom (MsdMediaKeysWindow *window,
         label_box_width = round (window_width);
         label_box_height = round (window_height * 0.175);
 
-        icon_box_x0 = (window_width - icon_box_width) / 2;
-        icon_box_y0 = (window_height - icon_box_height) / 2;
+        icon_box_x0 = round ((window_width - icon_box_width) / 2);
+        icon_box_y0 = round ((window_height - icon_box_height) / 2);
         label_box_y0 = round (window_height - label_box_height / 2);
 
 #if 0

--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -34,7 +34,7 @@
 
 #define MSD_MEDIA_KEYS_WINDOW_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MEDIA_KEYS_WINDOW, MsdMediaKeysWindowPrivate))
 
-#define ICON_SCALE 0.65           /* size of the icon compared to the whole OSD */
+#define ICON_SCALE 0.55           /* size of the icon compared to the whole OSD */
 
 struct MsdMediaKeysWindowPrivate
 {

--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -490,9 +490,9 @@ draw_action_volume (MsdMediaKeysWindow *window,
         volume_box_height = round (window_height * 0.05);
 
         icon_box_x0 = (window_width - icon_box_width) / 2;
-        icon_box_y0 = (window_height - icon_box_height - volume_box_height) / 2;
+        icon_box_y0 = (window_height - icon_box_height) / 2;
         volume_box_x0 = round (icon_box_x0);
-        volume_box_y0 = round (icon_box_height + icon_box_y0);
+        volume_box_y0 = round (window_height - icon_box_y0 / 2 - volume_box_height);
 
 #if 0
         g_message ("icon box: w=%f h=%f _x0=%f _y0=%f",

--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -34,6 +34,8 @@
 
 #define MSD_MEDIA_KEYS_WINDOW_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MEDIA_KEYS_WINDOW, MsdMediaKeysWindowPrivate))
 
+#define ICON_SCALE 0.65           /* size of the icon compared to the whole OSD */
+
 struct MsdMediaKeysWindowPrivate
 {
         MsdMediaKeysWindowAction action;
@@ -482,8 +484,8 @@ draw_action_volume (MsdMediaKeysWindow *window,
 
         gtk_window_get_size (GTK_WINDOW (window), &window_width, &window_height);
 
-        icon_box_width = round (window_width * 0.65);
-        icon_box_height = round (window_height * 0.65);
+        icon_box_width = round (window_width * ICON_SCALE);
+        icon_box_height = round (window_height * ICON_SCALE);
         volume_box_width = icon_box_width;
         volume_box_height = round (window_height * 0.05);
 
@@ -618,8 +620,8 @@ draw_action_custom (MsdMediaKeysWindow *window,
 
         gtk_window_get_size (GTK_WINDOW (window), &window_width, &window_height);
 
-        icon_box_width = round (window_width * 0.65);
-        icon_box_height = round (window_height * 0.65);
+        icon_box_width = round (window_width * ICON_SCALE);
+        icon_box_height = round (window_height * ICON_SCALE);
         label_box_width = round (window_width);
         label_box_height = round (window_height * 0.175);
 


### PR DESCRIPTION
Refer to some gnome commits:
https://github.com/GNOME/gnome-settings-daemon/commit/bacb20270cde60cc71bff6723336e50acc3935b2
https://github.com/GNOME/gnome-settings-daemon/commit/a03c072a8241d4d481ee94e5e1ffd829e85271f5

Before changed:
![screenshot at 2018-11-26 21-27-18](https://user-images.githubusercontent.com/33945019/48994808-0c57f900-f180-11e8-86a8-3b374fb511c3.png)

After changed:
![screenshot at 2018-11-26 21-25-19](https://user-images.githubusercontent.com/33945019/48994805-0a8e3580-f180-11e8-931b-6b47580ab1be.png)
