### PR TITLE
media-keys: Execute default calculator application defined by schema

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -527,6 +527,22 @@ do_media_action (MsdMediaKeysManager *manager)
 }
 
 static void
+do_calculator_action (MsdMediaKeysManager *manager)
+{
+        GSettings *settings;
+        char *calc;
+
+        settings = g_settings_new ("org.mate.applications-calculator");
+        calc = g_settings_get_string (settings, "exec");
+
+        if (calc)
+                execute (manager, calc, FALSE, FALSE);
+
+        g_free (calc);
+        g_object_unref (settings);
+}
+
+static void
 do_shutdown_action (MsdMediaKeysManager *manager)
 {
         execute (manager, "mate-session-save --shutdown-dialog", FALSE, FALSE);
@@ -1245,15 +1261,7 @@ do_action (MsdMediaKeysManager *manager,
                 do_media_action (manager);
                 break;
         case CALCULATOR_KEY:
-                if ((cmd = g_find_program_in_path ("galculator"))) {
-                        execute (manager, "galculator", FALSE, FALSE);
-                } else if ((cmd = g_find_program_in_path ("mate-calc"))) {
-                        execute (manager, "mate-calc", FALSE, FALSE);
-                } else {
-                        execute (manager, "gnome-calculator", FALSE, FALSE);
-                }
-
-                g_free (cmd);
+                do_calculator_action (manager);
                 break;
         case PLAY_KEY:
                 return do_multimedia_player_action (manager, "Play");


### PR DESCRIPTION
• Removes if-elif-else ladder that determines which calculator application to open when XF86Calculator is pressed
• Instead, when XF86Calculator is pressed, m-s-d executes the command listed in the default calculator application schema (defined in commit https://github.com/mate-desktop/mate-desktop/pull/341/commits/328116089489c674bad3b17bc69c267865968d24), And this PR is dependent on it
• Relevant PR:
https://github.com/mate-desktop/mate-desktop/pull/341