### PR TITLE
work around for intltool to fix distcheck on debian

### DIFF
--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -7,3 +7,4 @@
 # remove these unless you fix "make distcheck" a different way.
 #
 data/mate-settings-daemon.desktop.in
+sub/data/mate-settings-daemon.desktop.in


### PR DESCRIPTION
Just a work around, use this PR, `make distcheck` on debian will pass.

More info can found here:
https://github.com/mate-desktop/mate-settings-daemon/pull/259#issuecomment-462403038