### PR TITLE
Change url project's website

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 mate-settings-daemon is a fork of gnome-settings-daemon
 
-http://www.mate-desktop.org/
+https://mate-desktop.org/

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([msd_api_version],
 
 AC_INIT([mate-settings-daemon],
 	[msd_api_version_major.msd_api_version_minor.msd_api_version_micro],
-	[http://www.mate-desktop.org/])
+	[https://mate-desktop.org/])
 
 AC_CONFIG_SRCDIR([mate-settings-daemon/mate-settings-manager.c])
 AC_CONFIG_MACRO_DIR([m4])

--- a/plugins/datetime/org.mate.settingsdaemon.datetimemechanism.policy.in
+++ b/plugins/datetime/org.mate.settingsdaemon.datetimemechanism.policy.in
@@ -5,7 +5,7 @@
 
 <policyconfig>
   <vendor>The MATE Project</vendor>
-  <vendor_url>http://www.mate-desktop.org/</vendor_url>
+  <vendor_url>https://mate-desktop.org/</vendor_url>
   <icon_name>mate-panel-clock</icon_name>
 
   <action id="org.mate.settingsdaemon.datetimemechanism.settimezone">


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.