### PR TITLE
Avoid build warning

### DIFF
--- a/plugins/housekeeping/msd-ldsm-dialog.c
+++ b/plugins/housekeeping/msd-ldsm-dialog.c
@@ -160,7 +160,7 @@ ignore_check_button_toggled_cb (GtkToggleButton *button,
 
         settings_list = g_settings_get_strv (settings, SETTINGS_IGNORE_PATHS);
 
-        for (i = 0; i < G_N_ELEMENTS (settings_list); i++) {
+        for (i = 0; i < g_strv_length (settings_list); i++) {
                 if (settings_list[i] != NULL)
                         ignore_paths = g_slist_prepend (ignore_paths, g_strdup (settings_list[i]));
         }

--- a/plugins/housekeeping/msd-ldsm-dialog.c
+++ b/plugins/housekeeping/msd-ldsm-dialog.c
@@ -161,8 +161,7 @@ ignore_check_button_toggled_cb (GtkToggleButton *button,
         settings_list = g_settings_get_strv (settings, SETTINGS_IGNORE_PATHS);
 
         for (i = 0; i < g_strv_length (settings_list); i++) {
-                if (settings_list[i] != NULL)
-                        ignore_paths = g_slist_prepend (ignore_paths, g_strdup (settings_list[i]));
+                ignore_paths = g_slist_prepend (ignore_paths, g_strdup (settings_list[i]));
         }
         g_strfreev (settings_list);
 


### PR DESCRIPTION
```
/usr/include/glib-2.0/glib/gmacros.h:366:42: warning: division ‘sizeof (gchar ** {aka char **}) / sizeof (gchar * {aka char *})’ does not compute the number of array elements [-Wsizeof-pointer-div]
  366 | #define G_N_ELEMENTS(arr)  (sizeof (arr) / sizeof ((arr)[0]))
      |                                          ^
msd-ldsm-dialog.c:163:25: note: in expansion of macro ‘G_N_ELEMENTS’
  163 |         for (i = 0; i < G_N_ELEMENTS (settings_list); i++) {
      |                         ^~~~~~~~~~~~
```