### PR TITLE
mouse: Add acceleration profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,9 +196,9 @@ before_scripts:
   - fi
 
   - cd ${START_DIR}
-  - '[ -f mate-desktop-1.21.2.tar.xz ] || curl -Ls -o mate-desktop-1.21.2.tar.xz http://pub.mate-desktop.org/releases/1.21/mate-desktop-1.21.2.tar.xz'
-  - tar xf mate-desktop-1.21.2.tar.xz
-  - cd mate-desktop-1.21.2
+  - '[ -f mate-desktop-1.23.2.tar.xz ] || curl -Ls -o mate-desktop-1.23.2.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-desktop-1.23.2.tar.xz'
+  - tar xf mate-desktop-1.23.2.tar.xz
+  - cd mate-desktop-1.23.2
   - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
   -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
   - else

--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,14 @@
+### mate-settings-daemon 1.23.1
+
 ### mate-settings-daemon 1.23.0
 
-    tx: sync with transifex
-    media-keys: Execute default instant messaging application defined by schema
-    Change url project's website
-    locate-pointer: Do not grab pointer button when trying to locate
-    Create FUNDING.yml
-    [ci] Add cppcheck html report
-    [ci] Enable Clang Static Analyzer
+  * tx: sync with transifex
+  * media-keys: Execute default instant messaging application defined by schema
+  * Change url project's website
+  * locate-pointer: Do not grab pointer button when trying to locate
+  * Create FUNDING.yml
+  * [ci] Add cppcheck html report
+  * [ci] Enable Clang Static Analyzer
 
 ### mate-settings-daemon 1.22.0
 

--- a/configure.ac
+++ b/configure.ac
@@ -477,6 +477,7 @@ data/mate-settings-daemon.pc
 data/mate-settings-daemon-uninstalled.pc
 data/org.mate.applications-at.gschema.xml
 data/org.mate.font-rendering.gschema.xml
+data/org.mate.peripherals-keyboard.gschema.xml
 data/org.mate.peripherals-mouse.gschema.xml
 data/org.mate.peripherals-smartcard.gschema.xml
 data/org.mate.peripherals-touchpad.gschema.xml

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.60])
 
 m4_define([msd_api_version_major],[1])
 m4_define([msd_api_version_minor],[23])
-m4_define([msd_api_version_micro],[0])
+m4_define([msd_api_version_micro],[1])
 m4_define([msd_api_version],
 	[msd_api_version_major.msd_api_version_minor.msd_api_version_micro])
 
@@ -54,7 +54,7 @@ DBUS_GLIB_REQUIRED_VERSION=0.74
 GLIB_REQUIRED_VERSION=2.50.0
 GIO_REQUIRED_VERSION=2.50.0
 GTK_REQUIRED_VERSION=3.22.0
-MATE_DESKTOP_REQUIRED_VERSION=1.21.2
+MATE_DESKTOP_REQUIRED_VERSION=1.23.2
 LIBMATEKBD_REQUIRED_VERSION=1.17.0
 LIBNOTIFY_REQUIRED_VERSION=0.7.0
 LIBMATEMIXER_REQUIRED_VERSION=1.10.0

--- a/configure.ac
+++ b/configure.ac
@@ -477,6 +477,7 @@ data/mate-settings-daemon.pc
 data/mate-settings-daemon-uninstalled.pc
 data/org.mate.applications-at.gschema.xml
 data/org.mate.font-rendering.gschema.xml
+data/org.mate.peripherals-mouse.gschema.xml
 data/org.mate.peripherals-smartcard.gschema.xml
 data/org.mate.peripherals-touchpad.gschema.xml
 data/org.mate.SettingsDaemon.plugins.a11y-keyboard.gschema.xml

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@ NULL =
 msd_gschemas_in = \
 	org.mate.applications-at.gschema.xml.in \
 	org.mate.font-rendering.gschema.xml.in \
+	org.mate.peripherals-mouse.gschema.xml.in \
 	org.mate.peripherals-smartcard.gschema.xml.in \
 	org.mate.peripherals-touchpad.gschema.xml.in \
 	org.mate.SettingsDaemon.plugins.a11y-keyboard.gschema.xml.in \

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@ NULL =
 msd_gschemas_in = \
 	org.mate.applications-at.gschema.xml.in \
 	org.mate.font-rendering.gschema.xml.in \
+	org.mate.peripherals-keyboard.gschema.xml.in \
 	org.mate.peripherals-mouse.gschema.xml.in \
 	org.mate.peripherals-smartcard.gschema.xml.in \
 	org.mate.peripherals-touchpad.gschema.xml.in \

--- a/data/org.mate.peripherals-keyboard.gschema.xml.in
+++ b/data/org.mate.peripherals-keyboard.gschema.xml.in
@@ -1,0 +1,49 @@
+<schemalist gettext-domain="mate-desktop">
+  <enum id="org.mate.peripherals-keyboard.NumLockState">
+    <value nick="off" value="0"/>
+    <value nick="on" value="1"/>
+    <value nick="unknown" value="2"/>
+  </enum>
+  <schema id="org.mate.peripherals-keyboard" path="/org/mate/desktop/peripherals/keyboard/">
+    <key name="repeat" type="b">
+      <default>true</default>
+    </key>
+    <key name="click" type="b">
+      <default>true</default>
+    </key>
+    <key name="rate" type="i">
+      <default>30</default>
+    </key>
+    <key name="delay" type="i">
+      <default>500</default>
+    </key>
+    <key name="click-volume" type="i">
+      <default>0</default>
+    </key>
+    <key name="bell-mode" type="s">
+      <default>'on'</default>
+      <description>possible values are "on", "off", and "custom".</description>
+    </key>
+    <key name="bell-pitch" type="i">
+      <default>400</default>
+    </key>
+    <key name="bell-duration" type="i">
+      <default>100</default>
+    </key>
+    <key name="bell-custom-file" type="s">
+      <default>''</default>
+      <summary>Keyboard Bell Custom Filename</summary>
+      <description>File name of the bell sound to be played.</description>
+    </key>
+    <key name="remember-numlock-state" type="b">
+      <default>true</default>
+      <summary>Remember NumLock state</summary>
+      <description>When set to true, MATE will remember the state of the NumLock LED between sessions.</description>
+    </key>
+    <key name="numlock-state" enum="org.mate.peripherals-keyboard.NumLockState">
+      <default>'unknown'</default>
+      <summary>NumLock state</summary>
+      <description>The remembered state of the NumLock LED.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/data/org.mate.peripherals-mouse.gschema.xml.in
+++ b/data/org.mate.peripherals-mouse.gschema.xml.in
@@ -1,0 +1,59 @@
+<schemalist gettext-domain="mate-desktop">
+  <enum id="org.mate.peripherals-mouse.AccelProfile">
+    <value nick="default" value="0"/>
+    <value nick="adaptive" value="1"/>
+    <value nick="flat" value="2"/>
+  </enum>
+  <schema id="org.mate.peripherals-mouse" path="/org/mate/desktop/peripherals/mouse/">
+    <key name="left-handed" type="b">
+      <default>false</default>
+      <summary>Mouse button orientation</summary>
+      <description>Swap left and right mouse buttons for left-handed mice.</description>
+    </key>
+    <key name="motion-acceleration" type="d">
+      <default>-1</default>
+      <summary>Motion Acceleration</summary>
+      <description>Acceleration multiplier for mouse motion.  A value of -1 is the system default.</description>
+    </key>
+    <key name="motion-threshold" type="i">
+      <default>-1</default>
+      <summary>Motion Threshold</summary>
+      <description>Distance in pixels the pointer must move before accelerated mouse motion is activated.  A value of -1 is the system default.</description>
+    </key>
+    <key name="accel-profile" enum="org.mate.peripherals-mouse.AccelProfile">
+      <default>'default'</default>
+      <summary>Acceleration profile</summary>
+      <description>Acceleration profile used for connected mice. The acceleration profile can be set to either default ('default') which uses the default acceleration profile for each device, flat ('flat'), which accelerates by a device specific constant factor derived from the configured pointer speed, or adaptive ('adaptive') which adapts the acceleration depending on the mouse movement. If a mouse doesn't support the configured profile, 'default' will be used.</description>
+    </key>
+    <key name="drag-threshold" type="i">
+      <default>8</default>
+      <summary>Drag Threshold</summary>
+      <description>Distance before a drag is started.</description>
+    </key>
+    <key name="double-click" type="i">
+      <default>400</default>
+      <summary>Double Click Time</summary>
+      <description>Length of a double click.</description>
+    </key>
+    <key name="middle-button-enabled" type="b">
+      <default>true</default>
+      <summary>Middle button emulation</summary>
+      <description>Enables middle mouse button emulation through simultaneous left and right button click.</description>
+    </key>
+    <key name="locate-pointer" type="b">
+      <default>false</default>
+      <summary>Locate Pointer</summary>
+      <description>Highlights the current location of the pointer when the Control key is pressed and released.</description>
+    </key>
+    <key name="cursor-theme" type="s">
+      <default>''</default>
+      <summary>Cursor theme</summary>
+      <description>Cursor theme name.</description>
+    </key>
+    <key name="cursor-size" type="i">
+      <default>24</default>
+      <summary>Cursor size</summary>
+      <description>Size of the cursor referenced by cursor_theme.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/data/org.mate.peripherals-touchpad.gschema.xml.in
+++ b/data/org.mate.peripherals-touchpad.gschema.xml.in
@@ -4,6 +4,11 @@
     <value nick="left" value="1"/>
     <value nick="mouse" value="2"/>
   </enum>
+  <enum id="org.mate.peripherals-touchpad.AccelProfile">
+    <value nick="default" value="0"/>
+    <value nick="adaptive" value="1"/>
+    <value nick="flat" value="2"/>
+  </enum>
   <schema id="org.mate.peripherals-touchpad" path="/org/mate/desktop/peripherals/touchpad/">
     <key name="disable-while-typing" type="b">
       <default>false</default>
@@ -84,6 +89,11 @@
       <default>-1</default>
       <summary>Motion Threshold</summary>
       <description>Distance in pixels the pointer must move before accelerated touchpad motion is activated.  A value of -1 is the system default.</description>
+    </key>
+    <key name="accel-profile" enum="org.mate.peripherals-touchpad.AccelProfile">
+      <default>'default'</default>
+      <summary>Acceleration profile</summary>
+      <description>Acceleration profile used for touchpad. The acceleration profile can be set to either default ('default') which uses the default acceleration profile for each device, flat ('flat'), which accelerates by a device specific constant factor derived from the configured pointer speed, or adaptive ('adaptive') which adapts the acceleration depending on the touchpad movement. If a touchpad doesn't support the configured profile, 'default' will be used.</description>
     </key>
   </schema>
 </schemalist>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,6 +3,7 @@
 data/50-accessibility.xml.in
 [type: gettext/gsettings]data/org.mate.applications-at.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.font-rendering.gschema.xml.in
+[type: gettext/gsettings]data/org.mate.peripherals-keyboard.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.peripherals-mouse.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.peripherals-smartcard.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.peripherals-touchpad.gschema.xml.in

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,6 +3,7 @@
 data/50-accessibility.xml.in
 [type: gettext/gsettings]data/org.mate.applications-at.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.font-rendering.gschema.xml.in
+[type: gettext/gsettings]data/org.mate.peripherals-mouse.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.peripherals-smartcard.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.peripherals-touchpad.gschema.xml.in
 [type: gettext/gsettings]data/org.mate.SettingsDaemon.plugins.a11y-keyboard.gschema.xml.in


### PR DESCRIPTION
Currently libinput supports Adaptive and Flat acceleration profiles. We
can use these to change mouse behavior. Synaptic touchpads are not
supported through libinput, so they will not be affected by this change.

There does not seem to be a defined behavior for a Default acceleration
profile, so it's not included.

Multi-part patch:
* https://github.com/mate-desktop/mate-desktop/pull/407
* https://github.com/mate-desktop/mate-settings-daemon/pull/293
* https://github.com/mate-desktop/mate-control-center/pull/494