### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/plugins/datetime/Makefile.am
+++ b/plugins/datetime/Makefile.am
@@ -1,5 +1,5 @@
 dbus_servicesdir = $(datadir)/dbus-1/system-services
-dbus_confdir = $(sysconfdir)/dbus-1/system.d
+dbus_confdir = $(datadir)/dbus-1/system.d
 polkitdir = $(datadir)/polkit-1/actions
 
 dbus_services_in_files = org.mate.SettingsDaemon.DateTimeMechanism.service.in


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.