### PR TITLE
Hide MATE Settings Daemon from Startup Applications capplet

### DIFF
--- a/data/mate-settings-daemon.desktop.in.in
+++ b/data/mate-settings-daemon.desktop.in.in
@@ -6,3 +6,4 @@ OnlyShowIn=MATE;
 X-MATE-Autostart-Phase=Initialization
 X-MATE-Autostart-Notify=true
 X-MATE-AutoRestart=true
+NoDisplay=true


### PR DESCRIPTION
Autostart desktop files are hidden from the Startup Applications capplet. This pull request ensures that MATE Settings Daemon is not presented as an item that users can disable. See also:

  * https://github.com/mate-desktop/mate-session-manager/pull/213