### PR TITLE
Default DBUS_SYS_DIR to ${datadir}/dbus-1/system.d

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,7 @@ AC_ARG_WITH(dbus-services,
 if ! test -z "$with_dbus_sys" ; then
         DBUS_SYS_DIR="$with_dbus_sys"
 else
-        DBUS_SYS_DIR='${sysconfdir}/dbus-1/system.d'
+        DBUS_SYS_DIR='${datadir}/dbus-1/system.d'
 fi
 AC_SUBST(DBUS_SYS_DIR)
 


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.

Please **merge with #303**