### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/mate-settings-daemon/mate-settings-manager.c
+++ b/mate-settings-daemon/mate-settings-manager.c
@@ -60,9 +60,7 @@ enum {
 
 static guint signals [LAST_SIGNAL] = { 0, };
 
-static void     mate_settings_manager_class_init  (MateSettingsManagerClass *klass);
-static void     mate_settings_manager_init        (MateSettingsManager      *settings_manager);
-static void     mate_settings_manager_finalize    (GObject                   *object);
+static void     mate_settings_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MateSettingsManager, mate_settings_manager, G_TYPE_OBJECT)
 

--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -72,9 +72,7 @@ struct MsdA11yKeyboardManagerPrivate
 #endif /* HAVE_LIBNOTIFY */
 };
 
-static void     msd_a11y_keyboard_manager_class_init  (MsdA11yKeyboardManagerClass *klass);
-static void     msd_a11y_keyboard_manager_init        (MsdA11yKeyboardManager      *a11y_keyboard_manager);
-static void     msd_a11y_keyboard_manager_finalize    (GObject             *object);
+static void     msd_a11y_keyboard_manager_finalize (GObject *object);
 static void     msd_a11y_keyboard_manager_ensure_status_icon (MsdA11yKeyboardManager *manager);
 static void     set_server_from_settings (MsdA11yKeyboardManager *manager);
 

--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -109,9 +109,7 @@ enum {
         PROP_0,
 };
 
-static void     msd_a11y_preferences_dialog_class_init  (MsdA11yPreferencesDialogClass *klass);
-static void     msd_a11y_preferences_dialog_init        (MsdA11yPreferencesDialog      *a11y_preferences_dialog);
-static void     msd_a11y_preferences_dialog_finalize    (GObject                       *object);
+static void     msd_a11y_preferences_dialog_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdA11yPreferencesDialog, msd_a11y_preferences_dialog, GTK_TYPE_DIALOG)
 

--- a/plugins/a11y-settings/msd-a11y-settings-manager.c
+++ b/plugins/a11y-settings/msd-a11y-settings-manager.c
@@ -47,9 +47,7 @@ enum {
         PROP_0,
 };
 
-static void     msd_a11y_settings_manager_class_init  (MsdA11ySettingsManagerClass *klass);
-static void     msd_a11y_settings_manager_init        (MsdA11ySettingsManager      *a11y_settings_manager);
-static void     msd_a11y_settings_manager_finalize    (GObject                     *object);
+static void     msd_a11y_settings_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdA11ySettingsManager, msd_a11y_settings_manager, G_TYPE_OBJECT)
 

--- a/plugins/clipboard/msd-clipboard-manager.c
+++ b/plugins/clipboard/msd-clipboard-manager.c
@@ -79,9 +79,7 @@ typedef struct
         int         offset;
 } IncrConversion;
 
-static void     msd_clipboard_manager_class_init  (MsdClipboardManagerClass *klass);
-static void     msd_clipboard_manager_init        (MsdClipboardManager      *clipboard_manager);
-static void     msd_clipboard_manager_finalize    (GObject                  *object);
+static void     msd_clipboard_manager_finalize    (GObject *object);
 
 static void     clipboard_manager_watch_cb        (MsdClipboardManager *manager,
                                                    Window               window,

--- a/plugins/dummy/msd-dummy-manager.c
+++ b/plugins/dummy/msd-dummy-manager.c
@@ -48,9 +48,7 @@ enum {
         PROP_0,
 };
 
-static void     msd_dummy_manager_class_init  (MsdDummyManagerClass *klass);
-static void     msd_dummy_manager_init        (MsdDummyManager      *dummy_manager);
-static void     msd_dummy_manager_finalize    (GObject             *object);
+static void     msd_dummy_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdDummyManager, msd_dummy_manager, G_TYPE_OBJECT)
 

--- a/plugins/housekeeping/msd-housekeeping-manager.c
+++ b/plugins/housekeeping/msd-housekeeping-manager.c
@@ -44,9 +44,6 @@ struct MsdHousekeepingManagerPrivate {
         GSettings *settings;
 };
 
-static void     msd_housekeeping_manager_class_init  (MsdHousekeepingManagerClass *klass);
-static void     msd_housekeeping_manager_init        (MsdHousekeepingManager      *housekeeping_manager);
-
 G_DEFINE_TYPE_WITH_PRIVATE (MsdHousekeepingManager, msd_housekeeping_manager, G_TYPE_OBJECT)
 
 static gpointer manager_object = NULL;

--- a/plugins/housekeeping/msd-ldsm-dialog.c
+++ b/plugins/housekeeping/msd-ldsm-dialog.c
@@ -49,9 +49,6 @@ struct MsdLdsmDialogPrivate
         gchar *mount_path;
 };
 
-static void     msd_ldsm_dialog_class_init  (MsdLdsmDialogClass *klass);
-static void     msd_ldsm_dialog_init        (MsdLdsmDialog      *dialog);
-
 G_DEFINE_TYPE_WITH_PRIVATE (MsdLdsmDialog, msd_ldsm_dialog, GTK_TYPE_DIALOG);
 
 static const gchar*

--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -64,9 +64,7 @@ struct MsdKeybindingsManagerPrivate
         GSList      *screens;
 };
 
-static void     msd_keybindings_manager_class_init  (MsdKeybindingsManagerClass *klass);
-static void     msd_keybindings_manager_init        (MsdKeybindingsManager      *keybindings_manager);
-static void     msd_keybindings_manager_finalize    (GObject             *object);
+static void     msd_keybindings_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdKeybindingsManager, msd_keybindings_manager, G_TYPE_OBJECT)
 

--- a/plugins/keyboard/msd-keyboard-manager.c
+++ b/plugins/keyboard/msd-keyboard-manager.c
@@ -67,9 +67,7 @@ struct MsdKeyboardManagerPrivate {
 	GSettings  *settings;
 };
 
-static void     msd_keyboard_manager_class_init  (MsdKeyboardManagerClass* klass);
-static void     msd_keyboard_manager_init        (MsdKeyboardManager*      keyboard_manager);
-static void     msd_keyboard_manager_finalize    (GObject*                 object);
+static void     msd_keyboard_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdKeyboardManager, msd_keyboard_manager, G_TYPE_OBJECT)
 

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -99,9 +99,6 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-static void     msd_media_keys_manager_class_init  (MsdMediaKeysManagerClass *klass);
-static void     msd_media_keys_manager_init        (MsdMediaKeysManager      *media_keys_manager);
-
 G_DEFINE_TYPE_WITH_PRIVATE (MsdMediaKeysManager, msd_media_keys_manager, G_TYPE_OBJECT)
 
 static gpointer manager_object = NULL;

--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -108,9 +108,7 @@ typedef enum {
         ACCEL_PROFILE_FLAT
 } AccelProfile;
 
-static void     msd_mouse_manager_class_init  (MsdMouseManagerClass *klass);
-static void     msd_mouse_manager_init        (MsdMouseManager      *mouse_manager);
-static void     msd_mouse_manager_finalize    (GObject             *object);
+static void     msd_mouse_manager_finalize    (GObject              *object);
 static void     set_mouse_settings            (MsdMouseManager      *manager);
 static void     set_tap_to_click_synaptics    (XDeviceInfo          *device_info,
                                                gboolean              state,

--- a/plugins/mpris/msd-mpris-manager.c
+++ b/plugins/mpris/msd-mpris-manager.c
@@ -82,9 +82,7 @@ enum {
         PROP_0,
 };
 
-static void     msd_mpris_manager_class_init  (MsdMprisManagerClass *klass);
-static void     msd_mpris_manager_init        (MsdMprisManager      *mpris_manager);
-static void     msd_mpris_manager_finalize    (GObject              *object);
+static void     msd_mpris_manager_finalize    (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdMprisManager, msd_mpris_manager, G_TYPE_OBJECT)
 

--- a/plugins/rfkill/msd-rfkill-manager.c
+++ b/plugins/rfkill/msd-rfkill-manager.c
@@ -78,9 +78,7 @@ static const gchar introspection_xml[] =
 "  </interface>"
 "</node>";
 
-static void     msd_rfkill_manager_class_init  (MsdRfkillManagerClass *klass);
-static void     msd_rfkill_manager_init        (MsdRfkillManager      *rfkill_manager);
-static void     msd_rfkill_manager_finalize    (GObject                    *object);
+static void msd_rfkill_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdRfkillManager, msd_rfkill_manager, G_TYPE_OBJECT)
 

--- a/plugins/sound/msd-sound-manager.c
+++ b/plugins/sound/msd-sound-manager.c
@@ -52,8 +52,6 @@ struct MsdSoundManagerPrivate
 
 #define MATE_SOUND_SCHEMA "org.mate.sound"
 
-static void msd_sound_manager_class_init (MsdSoundManagerClass *klass);
-static void msd_sound_manager_init (MsdSoundManager *sound_manager);
 static void msd_sound_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdSoundManager, msd_sound_manager, G_TYPE_OBJECT)

--- a/plugins/typing-break/msd-typing-break-manager.c
+++ b/plugins/typing-break/msd-typing-break-manager.c
@@ -52,9 +52,7 @@ struct MsdTypingBreakManagerPrivate
         GSettings *settings;
 };
 
-static void     msd_typing_break_manager_class_init  (MsdTypingBreakManagerClass *klass);
-static void     msd_typing_break_manager_init        (MsdTypingBreakManager      *typing_break_manager);
-static void     msd_typing_break_manager_finalize    (GObject             *object);
+static void msd_typing_break_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdTypingBreakManager, msd_typing_break_manager, G_TYPE_OBJECT)
 

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -114,9 +114,7 @@ static const MateRRRotation possible_rotations[] = {
         /* We don't allow REFLECT_X or REFLECT_Y for now, as mate-display-properties doesn't allow them, either */
 };
 
-static void     msd_xrandr_manager_class_init  (MsdXrandrManagerClass *klass);
-static void     msd_xrandr_manager_init        (MsdXrandrManager      *xrandr_manager);
-static void     msd_xrandr_manager_finalize    (GObject             *object);
+static void msd_xrandr_manager_finalize (GObject *object);
 
 static void error_message (MsdXrandrManager *mgr, const char *primary_text, GError *error_to_display, const char *secondary_text);
 

--- a/plugins/xrdb/msd-xrdb-manager.c
+++ b/plugins/xrdb/msd-xrdb-manager.c
@@ -51,9 +51,7 @@ struct MsdXrdbManagerPrivate {
 	GtkWidget* widget;
 };
 
-static void     msd_xrdb_manager_class_init  (MsdXrdbManagerClass *klass);
-static void     msd_xrdb_manager_init        (MsdXrdbManager      *xrdb_manager);
-static void     msd_xrdb_manager_finalize    (GObject             *object);
+static void msd_xrdb_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MsdXrdbManager, msd_xrdb_manager, G_TYPE_OBJECT)
 

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -110,9 +110,7 @@ enum {
         MSD_XSETTINGS_ERROR_INIT
 };
 
-static void     mate_xsettings_manager_class_init  (MateXSettingsManagerClass *klass);
-static void     mate_xsettings_manager_init        (MateXSettingsManager      *xsettings_manager);
-static void     mate_xsettings_manager_finalize    (GObject                  *object);
+static void mate_xsettings_manager_finalize (GObject *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MateXSettingsManager, mate_xsettings_manager, G_TYPE_OBJECT)
 


### PR DESCRIPTION
Fixes the warnings:

[mate-settings-daemon-Wredundant-decls.txt](https://github.com/mate-desktop/mate-settings-daemon/files/3964304/mate-settings-daemon-Wredundant-decls.txt)