### PR TITLE
RDA: Don't apply stored monitor configuration if session is remote.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ MATE_DESKTOP_REQUIRED_VERSION=1.23.2
 LIBMATEKBD_REQUIRED_VERSION=1.17.0
 LIBNOTIFY_REQUIRED_VERSION=0.7.0
 LIBMATEMIXER_REQUIRED_VERSION=1.10.0
+RDA_REQUIRED_VERSION=0.0.3
 
 EXTRA_COMPILE_WARNINGS(yes)
 
@@ -364,6 +365,15 @@ fi
 AM_CONDITIONAL(BUILD_RFKILL, [test x"$enable_rfkill" = x"yes"])
 
 # ---------------------------------------------------------------------------
+# - Check if Remote Desktop Awareness support is available
+# ---------------------------------------------------------------------------
+
+PKG_CHECK_MODULES(RDA, rda >= $RDA_REQUIRED_VERSION, have_rda=yes, have_rda=no)
+if test "x$have_rda" = "xyes"; then
+  AC_DEFINE(HAVE_RDA, 1, [Have the Remote Desktop Awareness library])
+fi
+
+# ---------------------------------------------------------------------------
 # Enable Profiling
 # ---------------------------------------------------------------------------
 AC_ARG_ENABLE(profiling,
@@ -538,4 +548,5 @@ ${NSS_DATABASE:+\
     System nssdb:             ${NSS_DATABASE}
 }\
     Profiling support:        ${enable_profiling}
+    RD awareness:             ${have_rda}
 "

--- a/plugins/xrandr/Makefile.am
+++ b/plugins/xrandr/Makefile.am
@@ -67,6 +67,7 @@ libxrandr_la_CPPFLAGS =						\
 libxrandr_la_CFLAGS =			\
 	$(SETTINGS_PLUGIN_CFLAGS)	\
 	$(LIBNOTIFY_CFLAGS)		\
+	$(RDA_CFLAGS)			\
 	$(MATE_DESKTOP_CFLAGS)		\
 	$(AM_CFLAGS)
 
@@ -76,6 +77,7 @@ libxrandr_la_LDFLAGS = 			\
 libxrandr_la_LIBADD  =			\
 	$(SETTINGS_PLUGIN_LIBS)		\
 	$(LIBNOTIFY_LIBS)		\
+	$(RDA_LIBS)			\
 	$(MATE_DESKTOP_LIBS)
 
 plugin_in_files =			\

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -50,6 +50,10 @@
 #include <libnotify/notify.h>
 #endif
 
+#ifdef HAVE_RDA
+#include <rda/rda.h>
+#endif
+
 #include "mate-settings-profile.h"
 #include "msd-xrandr-manager.h"
 
@@ -2406,6 +2410,12 @@ apply_intended_configuration (MsdXrandrManager *manager, const char *intended_fi
 {
         GError *my_error;
         gboolean result;
+
+#ifdef HAVE_RDA
+	if (rda_session_is_remote()) {
+		return;
+	}
+#endif
 
         my_error = NULL;
         result = apply_configuration_from_filename (manager, intended_filename, TRUE, timestamp, &my_error);


### PR DESCRIPTION
With remote sessions (like X2Go, xRDP, etc.) the xRandR configuration is normally handled by the remote desktop technology in use.

This change adds a return early to MATE's xrandr MSD monitor resolution restoring code path, if the session is remote.

Note: this PR requires a new build dependency on librda [1]

[1] https://github.com/ArcticaProject/librda.git