### PR TITLE
housekeeping: Fix iconname of mate-disk-usage-analyzer

### DIFF
--- a/plugins/housekeeping/msd-ldsm-dialog.c
+++ b/plugins/housekeeping/msd-ldsm-dialog.c
@@ -443,7 +443,7 @@ msd_ldsm_dialog_new (gboolean     other_usable_partitions,
                 button_analyze = gtk_dialog_add_button (GTK_DIALOG (dialog),
                                                         _("Examine…"),
                                                         MSD_LDSM_DIALOG_RESPONSE_ANALYZE);
-                analyze_image = gtk_image_new_from_icon_name ("baobab", GTK_ICON_SIZE_BUTTON);
+                analyze_image = gtk_image_new_from_icon_name ("mate-disk-usage-analyzer", GTK_ICON_SIZE_BUTTON);
                 gtk_button_set_image (GTK_BUTTON (button_analyze), analyze_image);
         }
 


### PR DESCRIPTION
Before:

![Screenshot at 2020-03-04 10-16-09](https://user-images.githubusercontent.com/10171411/75868299-23b47600-5e08-11ea-8dd7-c29127c0fdb1.png)

After:

![Screenshot at 2020-03-04 11-04-17](https://user-images.githubusercontent.com/10171411/75868328-2c0cb100-5e08-11ea-80f4-a7c6f64dad2b.png)
