### PR TITLE
mouse: Remove warnings about absolute value function for long

### DIFF
--- a/plugins/mouse/msd-mouse-manager.c
+++ b/plugins/mouse/msd-mouse-manager.c
@@ -1360,11 +1360,11 @@ set_natural_scroll_synaptics (XDeviceInfo *device_info,
         if (rc == Success && type == XA_INTEGER && format == 32 && nitems >= 2) {
                 ptr = (glong *) data;
                 if (natural_scroll) {
-                        ptr[0] = -abs(ptr[0]);
-                        ptr[1] = -abs(ptr[1]);
+                        ptr[0] = -labs(ptr[0]);
+                        ptr[1] = -labs(ptr[1]);
                 } else {
-                        ptr[0] = abs(ptr[0]);
-                        ptr[1] = abs(ptr[1]);
+                        ptr[0] = labs(ptr[0]);
+                        ptr[1] = labs(ptr[1]);
                 }
 
                 XChangeDeviceProperty (GDK_DISPLAY_XDISPLAY (display), device, prop,


### PR DESCRIPTION
```
< msd-mouse-manager.c:1363:35: warning: absolute value function ‘abs’ given an argument of type ‘glong’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
<  1363 |                         ptr[0] = -abs(ptr[0]);
<       |                                   ^~~
< msd-mouse-manager.c:1364:35: warning: absolute value function ‘abs’ given an argument of type ‘glong’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
<  1364 |                         ptr[1] = -abs(ptr[1]);
<       |                                   ^~~
< msd-mouse-manager.c:1366:34: warning: absolute value function ‘abs’ given an argument of type ‘glong’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
<  1366 |                         ptr[0] = abs(ptr[0]);
<       |                                  ^~~
< msd-mouse-manager.c:1367:34: warning: absolute value function ‘abs’ given an argument of type ‘glong’ {aka ‘long int’} but has parameter of type ‘int’ which may cause truncation of value [-Wabsolute-value]
<  1367 |                         ptr[1] = abs(ptr[1]);
<       |                                  ^~~
```