### PR TITLE
Remove warnings about function declaration isn’t a prototype

### DIFF
--- a/plugins/housekeeping/msd-disk-space.c
+++ b/plugins/housekeeping/msd-disk-space.c
@@ -584,7 +584,7 @@ ldsm_is_hash_item_in_ignore_paths (gpointer key,
 }
 
 static void
-msd_ldsm_get_config ()
+msd_ldsm_get_config (void)
 {
         gchar **settings_list;
 

--- a/plugins/housekeeping/msd-ldsm-trash-empty.c
+++ b/plugins/housekeeping/msd-ldsm-trash-empty.c
@@ -233,7 +233,7 @@ trash_empty_job (GIOSchedulerJob *job,
 /* Worker thread end */
 
 static void
-trash_empty_start ()
+trash_empty_start (void)
 {
         GtkWidget *vbox1, *vbox2, *hbox;
         GtkWidget *label1, *label3;
@@ -340,7 +340,7 @@ trash_empty_require_confirmation (void)
 }
 
 static void
-trash_empty_show_confirmation_dialog ()
+trash_empty_show_confirmation_dialog (void)
 {
         GtkWidget *button;
 

--- a/plugins/keyboard/msd-keyboard-xkb.c
+++ b/plugins/keyboard/msd-keyboard-xkb.c
@@ -163,7 +163,7 @@ apply_desktop_settings_cb (GSettings *settings, gchar *key, gpointer   user_data
 }
 
 static void
-popup_menu_launch_capplet ()
+popup_menu_launch_capplet (void)
 {
 	GAppInfo *info;
 	GdkAppLaunchContext *context;
@@ -195,7 +195,7 @@ show_layout_destroy (GtkWidget * dialog, gint group)
 }
 
 static void
-popup_menu_show_layout ()
+popup_menu_show_layout (void)
 {
 	GtkWidget *dialog;
 	XklEngine *engine = xkl_engine_get_instance (GDK_DISPLAY_XDISPLAY(gdk_display_get_default()));
@@ -285,13 +285,13 @@ status_icon_popup_menu_cb (GtkStatusIcon * icon, guint button, guint time)
 	item =
 	    gtk_menu_item_new_with_mnemonic (_("Keyboard _Preferences"));
 	gtk_widget_show (item);
-	g_signal_connect (item, "activate", popup_menu_launch_capplet,
+	g_signal_connect (item, "activate", G_CALLBACK (popup_menu_launch_capplet),
 			  NULL);
 	gtk_menu_shell_append (GTK_MENU_SHELL (popup_menu), item);
 
 	item = gtk_menu_item_new_with_mnemonic (_("Show _Current Layout"));
 	gtk_widget_show (item);
-	g_signal_connect (item, "activate", popup_menu_show_layout, NULL);
+	g_signal_connect (item, "activate", G_CALLBACK (popup_menu_show_layout), NULL);
 	gtk_menu_shell_append (GTK_MENU_SHELL (popup_menu), item);
 
 	for (i = 0; *current_name; i++, current_name++) {
@@ -330,7 +330,7 @@ status_icon_popup_menu_cb (GtkStatusIcon * icon, guint button, guint time)
 }
 
 static void
-show_hide_icon ()
+show_hide_icon (void)
 {
 	if (g_strv_length (current_kbd_config.layouts_variants) > 1) {
 		if (icon == NULL) {
@@ -512,7 +512,7 @@ msd_keyboard_new_device (XklEngine * engine)
 }
 
 static void
-msd_keyboard_update_indicator_icons ()
+msd_keyboard_update_indicator_icons (void)
 {
 	Bool state;
 	int new_state, i;

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -227,7 +227,7 @@ translate_bool_int },
  * A lot of this code is shamelessly copied and adapted from Linux Mint/Cinnamon.
  */
 static int
-get_window_scale_auto ()
+get_window_scale_auto (void)
 {
         GdkDisplay   *display;
         GdkMonitor   *monitor;


### PR DESCRIPTION
```
< msd-ldsm-trash-empty.c:236:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   236 | trash_empty_start ()
<       | ^~~~~~~~~~~~~~~~~
< msd-ldsm-trash-empty.c:343:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   343 | trash_empty_show_confirmation_dialog ()
<       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

< msd-disk-space.c:587:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   587 | msd_ldsm_get_config ()
<       | ^~~~~~~~~~~~~~~~~~~

< msd-keyboard-xkb.c:166:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   166 | popup_menu_launch_capplet ()
<       | ^~~~~~~~~~~~~~~~~~~~~~~~~
< msd-keyboard-xkb.c:198:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   198 | popup_menu_show_layout ()
<       | ^~~~~~~~~~~~~~~~~~~~~~
< msd-keyboard-xkb.c:333:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   333 | show_hide_icon ()
<       | ^~~~~~~~~~~~~~
< msd-keyboard-xkb.c:515:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   515 | msd_keyboard_update_indicator_icons ()
<       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


< msd-xsettings-manager.c:230:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
<   230 | get_window_scale_auto ()
<       | ^~~~~~~~~~~~~~~~~~~~~
```