### PR TITLE
build: Using --header and --body at the same time is deprecated

### DIFF
--- a/plugins/media-keys/Makefile.am
+++ b/plugins/media-keys/Makefile.am
@@ -17,7 +17,7 @@ msd-media-keys-manager-glue.h: msd-media-keys-manager.xml Makefile
 	&& rm -f xgen-$(@F)
 
 msd-marshal.c: msd-marshal.list
-	$(AM_V_GEN) $(GLIB_GENMARSHAL) --prefix=msd_marshal $< --header --body --internal > $@
+	$(AM_V_GEN) $(GLIB_GENMARSHAL) --prefix=msd_marshal $< --body --prototypes --internal > $@
 
 msd-marshal.h: msd-marshal.list
 	$(AM_V_GEN) $(GLIB_GENMARSHAL) --prefix=msd_marshal $< --header --internal > $@


### PR DESCRIPTION
`dbus-binding-tool` also displays this warning, that should disappear after porting to `gdbus-codegen`.