### PR TITLE
msd-media-keys-manager: comparison of unsigned expression in '< 0' is always false

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -780,7 +780,7 @@ do_sound_action (MsdMediaKeysManager *manager,
         }
 
         update_dialog (manager,
-                       CLAMP (100 * volume / (volume_max - volume_min), 0, 100),
+                       MIN (100 * volume / (volume_max - volume_min), 100),
                        muted,
                        sound_changed,
                        quiet,


### PR DESCRIPTION
```
msd-media-keys-manager.c: In function 'do_sound_action':
/usr/include/glib-2.0/glib/gmacros.h:813:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  813 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
msd-media-keys-manager.c:783:24: note: in expansion of macro 'CLAMP'
  783 |                        CLAMP (100 * volume / (volume_max - volume_min), 0, 100),
      |                        ^~~~~
```