### PR TITLE
Add suport for customizing togglekeys feedback

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -1102,7 +1102,11 @@ msd_a11y_keyboard_manager_start (MsdA11yKeyboardManager *manager,
 {
         mate_settings_profile_start (NULL);
 
-        g_idle_add ((GSourceFunc) start_a11y_keyboard_idle_cb, manager);
+        /* give our initialization a lower priority over msd-keyoboard so it
+         * restores the numlock state before we might start monitoring it */
+        g_idle_add_full (G_PRIORITY_LOW,
+                         (GSourceFunc) start_a11y_keyboard_idle_cb, manager,
+                         NULL);
 
         mate_settings_profile_end (NULL);
 

--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -948,6 +948,53 @@ set_settings_from_server (MsdA11yKeyboardManager *manager)
         g_object_unref (settings);
 }
 
+typedef struct {
+        GdkDisplay *display;
+        gint count;
+} BeepSequenceData;
+
+static gboolean
+on_beep_dequence_timeout (gpointer user_data)
+{
+        BeepSequenceData *data = user_data;
+
+        gdk_display_beep (data->display);
+        data->count--;
+
+        return data->count > 0;
+}
+
+static void
+beep_sequence (MsdA11yKeyboardManager  *manager,
+               GdkDisplay              *display,
+               gint                     count,
+               gint                     delay)
+{
+        g_return_if_fail (MSD_IS_A11Y_KEYBOARD_MANAGER (manager));
+
+        if (count < 1)
+                return;
+
+        if (! display)
+                display = gdk_display_get_default ();
+
+        gdk_display_beep (display);
+        if (count > 1) {
+                BeepSequenceData *data = g_malloc (sizeof *data);
+
+                data->display = display;
+                data->count = count - 1;
+
+                /* don't allow a delay below 50ms, it doesn't make much sense
+                 * anyway and is more likely to be a broken setting */
+                g_warn_if_fail (delay >= 50);
+                delay = MAX (delay, 50);
+
+                g_timeout_add_full (G_PRIORITY_DEFAULT, (guint) delay,
+                                    on_beep_dequence_timeout, data, g_free);
+        }
+}
+
 static GdkFilterReturn
 cb_xkb_event_filter (GdkXEvent              *xevent,
                      GdkEvent               *ignored1,
@@ -970,6 +1017,21 @@ cb_xkb_event_filter (GdkXEvent              *xevent,
                          * set_settings_from_server().
                          */
                 }
+        } else if (xev->xany.type == (manager->priv->xkbEventBase + XkbEventCode) &&
+                   xkbEv->any.xkb_type == XkbIndicatorStateNotify &&
+                   g_settings_get_boolean (manager->priv->settings, "togglekeys-enable")) {
+                GdkDisplay *display = gdk_x11_lookup_xdisplay (xkbEv->any.display);
+                gint beep_count;
+                gint beep_delay;
+
+                if (xkbEv->indicators.state & xkbEv->indicators.changed) {
+                        beep_count = g_settings_get_int (manager->priv->settings, "togglekeys-enable-beep-count");
+                        beep_delay = g_settings_get_int (manager->priv->settings, "togglekeys-enable-beep-delay");
+                } else {
+                        beep_count = g_settings_get_int (manager->priv->settings, "togglekeys-disable-beep-count");
+                        beep_delay = g_settings_get_int (manager->priv->settings, "togglekeys-disable-beep-delay");
+                }
+                beep_sequence (manager, display, beep_count, beep_delay);
         }
 
         return GDK_FILTER_CONTINUE;
@@ -1005,6 +1067,7 @@ start_a11y_keyboard_idle_cb (MsdA11yKeyboardManager *manager)
         manager->priv->original_xkb_desc = get_xkb_desc_rec (manager);
 
         event_mask = XkbControlsNotifyMask;
+        event_mask |= XkbIndicatorStateNotifyMask;
 #ifdef MATE_ENABLE_DEBUG
         event_mask |= XkbAccessXNotifyMask; /* make default when AXN_AXKWarning works */
 #endif /* MATE_ENABLE_DEBUG */

--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -982,13 +982,16 @@ beep_sequence (MsdA11yKeyboardManager  *manager,
         if (count > 1) {
                 BeepSequenceData *data = g_malloc (sizeof *data);
 
-                data->display = display;
-                data->count = count - 1;
+                /* don't allow more than 8 beeps total, nor a delay outside
+                 * the range 50ms-5s: anything outside this is not very
+                 * reasonable and is more likely to be a broken setting,
+                 * and we don't want to be beeping forever. */
+                g_warn_if_fail (count <= 8);
+                g_warn_if_fail (delay >= 50 && delay <= 5000);
 
-                /* don't allow a delay below 50ms, it doesn't make much sense
-                 * anyway and is more likely to be a broken setting */
-                g_warn_if_fail (delay >= 50);
-                delay = MAX (delay, 50);
+                data->display = display;
+                data->count = MIN (8, count) - 1;
+                delay = CLAMP (delay, 50, 5000);
 
                 g_timeout_add_full (G_PRIORITY_DEFAULT, (guint) delay,
                                     on_beep_dequence_timeout, data, g_free);


### PR DESCRIPTION
This allows a customizable and possibly different beep sequence when a togglekey is enabled or disabled.  This is very useful for the user to know for sure whether the feature got enabled or disabled.

Back in the days of buzzers, XKB was supposed to use different sounds for each of those, but this is no longer the case now in the vast majority of setups the beeps are intercepted and use a single recorded sound.

So instead provide an implementation for togglekeys on our end by listening to the `XkbIndicatorStateNotify` events, and provide options to control the feedback.  The XKB implementation is still available, and used by default for now (see https://github.com/mate-desktop/mate-desktop/pull/451).

This depends on https://github.com/mate-desktop/mate-desktop/pull/451, but I didn't bump the mate-desktop dependency because it's already done in #330, so I'm trying to avoid merge conflicts here.  But this means you still need latest mate-desktop to run this PR (not build it).