### PR TITLE
add G_GNUC_UNUSED in some unused parameters

### DIFF
--- a/mate-settings-daemon/main.c
+++ b/mate-settings-daemon/main.c
@@ -444,7 +444,9 @@ parse_args (int *argc, char ***argv)
             g_setenv ("G_MESSAGES_DEBUG", "all", FALSE);
 }
 
-static void debug_changed (GSettings *settings, gchar *key, gpointer user_data)
+static void debug_changed (GSettings *settings,
+                           gchar     *key G_GNUC_UNUSED,
+                           gpointer   user_data G_GNUC_UNUSED)
 {
         debug = g_settings_get_boolean (settings, DEBUG_KEY);
         if (debug) {

--- a/mate-settings-daemon/mate-settings-plugin-info.c
+++ b/mate-settings-daemon/mate-settings-plugin-info.c
@@ -266,7 +266,7 @@ mate_settings_plugin_info_fill_from_file (MateSettingsPluginInfo *info,
 }
 
 static void
-plugin_enabled_cb (GSettings              *settings,
+plugin_enabled_cb (GSettings              *settings G_GNUC_UNUSED,
                    gchar                  *key,
                    MateSettingsPluginInfo *info)
 {

--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -497,7 +497,7 @@ maybe_show_status_icon (MsdA11yKeyboardManager *manager)
 
 #ifdef HAVE_LIBNOTIFY
 static void
-on_notification_closed (NotifyNotification     *notification,
+on_notification_closed (NotifyNotification     *notification G_GNUC_UNUSED,
                         MsdA11yKeyboardManager *manager)
 {
         g_object_unref (manager->priv->notification);
@@ -985,8 +985,8 @@ cb_xkb_event_filter (GdkXEvent              *xevent,
 }
 
 static void
-keyboard_callback (GSettings              *settings,
-                   gchar                  *key,
+keyboard_callback (GSettings              *settings G_GNUC_UNUSED,
+                   gchar                  *key G_GNUC_UNUSED,
                    MsdA11yKeyboardManager *manager)
 {
         set_server_from_settings (manager);
@@ -1151,7 +1151,7 @@ msd_a11y_keyboard_manager_class_init (MsdA11yKeyboardManagerClass *klass)
 
 static void
 on_preferences_dialog_response (GtkDialog              *dialog,
-                                int                     response,
+                                int                     response G_GNUC_UNUSED,
                                 MsdA11yKeyboardManager *manager)
 {
         g_signal_handlers_disconnect_by_func (dialog,
@@ -1163,7 +1163,7 @@ on_preferences_dialog_response (GtkDialog              *dialog,
 }
 
 static void
-on_status_icon_activate (GtkStatusIcon          *status_icon,
+on_status_icon_activate (GtkStatusIcon          *status_icon G_GNUC_UNUSED,
                          MsdA11yKeyboardManager *manager)
 {
         if (manager->priv->preferences_dialog == NULL) {

--- a/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
+++ b/plugins/a11y-keyboard/msd-a11y-preferences-dialog.c
@@ -126,7 +126,7 @@ msd_a11y_preferences_dialog_class_init (MsdA11yPreferencesDialogClass *klass)
 }
 
 static void
-on_response (MsdA11yPreferencesDialog *dialog,
+on_response (MsdA11yPreferencesDialog *dialog G_GNUC_UNUSED,
              gint                      response_id)
 {
         switch (response_id) {
@@ -478,7 +478,7 @@ on_at_screen_magnifier_checkbutton_toggled (GtkToggleButton          *button,
 
 static void
 on_large_print_checkbutton_toggled (GtkToggleButton          *button,
-                                    MsdA11yPreferencesDialog *dialog)
+                                    MsdA11yPreferencesDialog *dialog G_GNUC_UNUSED)
 {
         config_set_large_print (gtk_toggle_button_get_active (button));
 }

--- a/plugins/a11y-settings/msd-a11y-settings-manager.c
+++ b/plugins/a11y-settings/msd-a11y-settings-manager.c
@@ -54,7 +54,7 @@ G_DEFINE_TYPE_WITH_PRIVATE (MsdA11ySettingsManager, msd_a11y_settings_manager, G
 static gpointer manager_object = NULL;
 
 static void
-apps_settings_changed (GSettings              *settings,
+apps_settings_changed (GSettings              *settings G_GNUC_UNUSED,
 		       const char             *key,
 		       MsdA11ySettingsManager *manager)
 {

--- a/plugins/background/msd-background-manager.c
+++ b/plugins/background/msd-background-manager.c
@@ -232,7 +232,7 @@ draw_background (MsdBackgroundManager *manager,
 }
 
 static void
-on_bg_changed (MateBG               *bg,
+on_bg_changed (MateBG               *bg G_GNUC_UNUSED,
 	       MsdBackgroundManager *manager)
 {
 	g_debug ("Background changed");
@@ -240,7 +240,7 @@ on_bg_changed (MateBG               *bg,
 }
 
 static void
-on_bg_transitioned (MateBG               *bg,
+on_bg_transitioned (MateBG               *bg G_GNUC_UNUSED,
 		    MsdBackgroundManager *manager)
 {
 	g_debug ("Background transitioned");
@@ -308,9 +308,9 @@ settings_change_event_idle_cb (MsdBackgroundManager *manager)
 }
 
 static gboolean
-settings_change_event_cb (GSettings            *settings,
-			  gpointer              keys,
-			  gint                  n_keys,
+settings_change_event_cb (GSettings            *settings G_GNUC_UNUSED,
+			  gpointer              keys G_GNUC_UNUSED,
+			  gint                  n_keys G_GNUC_UNUSED,
 			  MsdBackgroundManager *manager)
 {
 	MsdBackgroundManagerPrivate *p = manager->priv;
@@ -375,8 +375,8 @@ remove_background (MsdBackgroundManager *manager)
 }
 
 static void
-on_bg_handling_changed (GSettings            *settings,
-			const char           *key,
+on_bg_handling_changed (GSettings            *settings G_GNUC_UNUSED,
+			const char           *key G_GNUC_UNUSED,
 			MsdBackgroundManager *manager)
 {
 	MsdBackgroundManagerPrivate *p = manager->priv;
@@ -433,10 +433,10 @@ disconnect_session_manager_listener (MsdBackgroundManager* manager)
 }
 
 static void
-on_session_manager_signal (GDBusProxy   *proxy,
-			   const gchar  *sender_name,
+on_session_manager_signal (GDBusProxy   *proxy G_GNUC_UNUSED,
+			   const gchar  *sender_name G_GNUC_UNUSED,
 			   const gchar  *signal_name,
-			   GVariant     *parameters,
+			   GVariant     *parameters G_GNUC_UNUSED,
 			   gpointer      user_data)
 {
 	MsdBackgroundManager *manager = MSD_BACKGROUND_MANAGER (user_data);

--- a/plugins/datetime/system-timezone.c
+++ b/plugins/datetime/system-timezone.c
@@ -250,9 +250,9 @@ system_timezone_finalize (GObject *obj)
 }
 
 static void
-system_timezone_monitor_changed (GFileMonitor *handle,
-                                 GFile *file,
-                                 GFile *other_file,
+system_timezone_monitor_changed (GFileMonitor *handle G_GNUC_UNUSED,
+                                 GFile *file G_GNUC_UNUSED,
+                                 GFile *other_file G_GNUC_UNUSED,
                                  GFileMonitorEvent event,
                                  gpointer user_data)
 {

--- a/plugins/housekeeping/msd-disk-space.c
+++ b/plugins/housekeeping/msd-disk-space.c
@@ -554,8 +554,8 @@ ldsm_is_hash_item_not_in_mounts (gpointer key,
 }
 
 static void
-ldsm_mounts_changed (GObject  *monitor,
-                     gpointer  data)
+ldsm_mounts_changed (GObject  *monitor G_GNUC_UNUSED,
+                     gpointer  data G_GNUC_UNUSED)
 {
         GList *mounts;
 
@@ -636,9 +636,9 @@ msd_ldsm_get_config (void)
 }
 
 static void
-msd_ldsm_update_config (GSettings *settings,
-                        gchar *key,
-                        gpointer user_data)
+msd_ldsm_update_config (GSettings *settings G_GNUC_UNUSED,
+                        gchar *key G_GNUC_UNUSED,
+                        gpointer user_data G_GNUC_UNUSED)
 {
         msd_ldsm_get_config ();
 }

--- a/plugins/housekeeping/msd-housekeeping-manager.c
+++ b/plugins/housekeeping/msd-housekeeping-manager.c
@@ -232,9 +232,9 @@ do_cleanup_soon (MsdHousekeepingManager *manager)
 }
 
 static void
-settings_changed_callback (GSettings              *settings,
-			   const char             *key,
-			   MsdHousekeepingManager *manager)
+settings_changed_callback (GSettings              *settings G_GNUC_UNUSED,
+                           const char             *key G_GNUC_UNUSED,
+                           MsdHousekeepingManager *manager)
 {
         do_cleanup_soon (manager);
 }

--- a/plugins/housekeeping/msd-ldsm-trash-empty.c
+++ b/plugins/housekeeping/msd-ldsm-trash-empty.c
@@ -317,7 +317,7 @@ trash_empty_start (void)
 static void
 trash_empty_confirmation_response (GtkDialog *dialog,
                                    gint       response_id,
-                                   gpointer   user_data)
+                                   gpointer   user_data G_GNUC_UNUSED)
 {
         if (response_id == GTK_RESPONSE_YES)
                 trash_empty_start ();

--- a/plugins/keybindings/msd-keybindings-manager.c
+++ b/plugins/keybindings/msd-keybindings-manager.c
@@ -500,10 +500,10 @@ keybindings_filter (GdkXEvent             *gdk_xevent,
 }
 
 static void
-bindings_callback (DConfClient           *client,
-                   gchar                 *prefix,
-                   GStrv                  changes,
-                   gchar                 *tag,
+bindings_callback (DConfClient           *client G_GNUC_UNUSED,
+                   gchar                 *prefix G_GNUC_UNUSED,
+                   GStrv                  changes G_GNUC_UNUSED,
+                   gchar                 *tag G_GNUC_UNUSED,
                    MsdKeybindingsManager *manager)
 {
         g_debug ("keybindings: received 'changed' signal from dconf");

--- a/plugins/keyboard/msd-keyboard-xkb.c
+++ b/plugins/keyboard/msd-keyboard-xkb.c
@@ -157,7 +157,9 @@ apply_desktop_settings (void)
 }
 
 static void
-apply_desktop_settings_cb (GSettings *settings, gchar *key, gpointer   user_data)
+apply_desktop_settings_cb (GSettings *settings G_GNUC_UNUSED,
+                           gchar     *key G_GNUC_UNUSED,
+                           gpointer   user_data G_GNUC_UNUSED)
 {
     apply_desktop_settings ();
 }
@@ -189,7 +191,8 @@ popup_menu_launch_capplet (void)
 }
 
 static void
-show_layout_destroy (GtkWidget * dialog, gint group)
+show_layout_destroy (GtkWidget *dialog G_GNUC_UNUSED,
+                     gint       group)
 {
 	g_hash_table_remove (preview_dialogs, GINT_TO_POINTER (group));
 }
@@ -228,7 +231,8 @@ popup_menu_show_layout (void)
 }
 
 static void
-popup_menu_set_group (GtkMenuItem * item, gpointer param)
+popup_menu_set_group (GtkMenuItem *item G_GNUC_UNUSED,
+                      gpointer     param)
 {
 	gint group_number = GPOINTER_TO_INT (param);
 	XklEngine *engine = matekbd_status_get_xkl_engine ();
@@ -471,7 +475,9 @@ apply_xkb_settings (void)
 }
 
 static void
-apply_xkb_settings_cb (GSettings *settings, gchar *key, gpointer   user_data)
+apply_xkb_settings_cb (GSettings *settings G_GNUC_UNUSED,
+                       gchar     *key G_GNUC_UNUSED,
+                       gpointer   user_data G_GNUC_UNUSED)
 {
     apply_xkb_settings ();
 }
@@ -505,7 +511,7 @@ msd_keyboard_xkb_evt_filter (GdkXEvent * xev, GdkEvent * event)
 
 /* When new Keyboard is plugged in - reload the settings */
 static void
-msd_keyboard_new_device (XklEngine * engine)
+msd_keyboard_new_device (XklEngine * engine G_GNUC_UNUSED)
 {
 	apply_desktop_settings ();
 	apply_xkb_settings ();
@@ -543,8 +549,10 @@ msd_keyboard_update_indicator_icons (void)
 }
 
 static void
-msd_keyboard_state_changed (XklEngine * engine, XklEngineStateChange type,
-			    gint new_group, gboolean restore)
+msd_keyboard_state_changed (XklEngine           *engine G_GNUC_UNUSED,
+                            XklEngineStateChange type,
+                            gint                 new_group,
+                            gboolean             restore)
 {
 	xkl_debug (160,
 		   "State changed: type %d, new group: %d, restore: %d.\n",

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -853,8 +853,8 @@ update_default_input (MsdMediaKeysManager *manager)
 }
 
 static void
-on_context_state_notify (MateMixerContext    *context,
-                         GParamSpec          *pspec,
+on_context_state_notify (MateMixerContext    *context G_GNUC_UNUSED,
+                         GParamSpec          *pspec G_GNUC_UNUSED,
                          MsdMediaKeysManager *manager)
 {
         update_default_output (manager);
@@ -862,23 +862,23 @@ on_context_state_notify (MateMixerContext    *context,
 }
 
 static void
-on_context_default_output_notify (MateMixerContext    *context,
-                                  GParamSpec          *pspec,
+on_context_default_output_notify (MateMixerContext    *context G_GNUC_UNUSED,
+                                  GParamSpec          *pspec G_GNUC_UNUSED,
                                   MsdMediaKeysManager *manager)
 {
         update_default_output (manager);
 }
 
 static void
-on_context_default_input_notify (MateMixerContext    *context,
-                                 GParamSpec          *pspec,
+on_context_default_input_notify (MateMixerContext    *context G_GNUC_UNUSED,
+                                 GParamSpec          *pspec G_GNUC_UNUSED,
                                  MsdMediaKeysManager *manager)
 {
         update_default_input (manager);
 }
 
 static void
-on_context_stream_removed (MateMixerContext    *context,
+on_context_stream_removed (MateMixerContext    *context G_GNUC_UNUSED,
                            const gchar         *name,
                            MsdMediaKeysManager *manager)
 {

--- a/plugins/mouse/msd-locate-pointer.c
+++ b/plugins/mouse/msd-locate-pointer.c
@@ -166,7 +166,7 @@ update_shape (MsdLocatePointerData *data)
 }
 
 static void
-timeline_frame_cb (MsdTimeline *timeline,
+timeline_frame_cb (MsdTimeline *timeline G_GNUC_UNUSED,
 		   gdouble      progress,
 		   gpointer     user_data)
 {
@@ -250,7 +250,7 @@ composited_changed (GdkScreen            *screen,
 }
 
 static void
-timeline_finished_cb (MsdTimeline *timeline,
+timeline_finished_cb (MsdTimeline *timeline G_GNUC_UNUSED,
 		      gpointer     user_data)
 {
   MsdLocatePointerData *data = (MsdLocatePointerData *) user_data;
@@ -266,7 +266,7 @@ timeline_finished_cb (MsdTimeline *timeline,
 }
 
 static void
-locate_pointer_unrealize_cb (GtkWidget            *widget,
+locate_pointer_unrealize_cb (GtkWidget            *widget G_GNUC_UNUSED,
                              MsdLocatePointerData *data)
 {
   if (data->window != NULL)
@@ -279,7 +279,7 @@ locate_pointer_unrealize_cb (GtkWidget            *widget,
 }
 
 static void
-locate_pointer_realize_cb (GtkWidget            *widget,
+locate_pointer_realize_cb (GtkWidget            *widget G_GNUC_UNUSED,
                            MsdLocatePointerData *data)
 {
   GdkDisplay *display;
@@ -321,7 +321,7 @@ locate_pointer_realize_cb (GtkWidget            *widget,
 }
 
 static gboolean
-locate_pointer_draw_cb (GtkWidget      *widget,
+locate_pointer_draw_cb (GtkWidget      *widget G_GNUC_UNUSED,
                         cairo_t        *cr,
                         gpointer        user_data)
 {

--- a/plugins/mpris/bus-watch-namespace.c
+++ b/plugins/mpris/bus-watch-namespace.c
@@ -240,9 +240,9 @@ names_listed (GObject      *object,
 }
 
 static void
-connection_closed (GDBusConnection *connection,
-                   gboolean         remote_peer_vanished,
-                   GError          *error,
+connection_closed (GDBusConnection *connection G_GNUC_UNUSED,
+                   gboolean         remote_peer_vanished G_GNUC_UNUSED,
+                   GError          *error G_GNUC_UNUSED,
                    gpointer         user_data)
 {
   NamespaceWatcher *watcher = user_data;

--- a/plugins/mpris/msd-mpris-manager.c
+++ b/plugins/mpris/msd-mpris-manager.c
@@ -223,8 +223,8 @@ grab_media_player_keys (MsdMprisManager *manager)
 }
 
 static void
-key_pressed (GDBusProxy          *proxy,
-             gchar               *sender_name,
+key_pressed (GDBusProxy          *proxy G_GNUC_UNUSED,
+             gchar               *sender_name G_GNUC_UNUSED,
              gchar               *signal_name,
              GVariant            *parameters,
              MsdMprisManager     *manager)

--- a/plugins/rfkill/msd-rfkill-manager.c
+++ b/plugins/rfkill/msd-rfkill-manager.c
@@ -249,9 +249,9 @@ engine_properties_changed (MsdRfkillManager *manager)
 }
 
 static void
-rfkill_changed (CcRfkillGlib     *rfkill,
-		GList            *events,
-		MsdRfkillManager  *manager)
+rfkill_changed (CcRfkillGlib     *rfkill G_GNUC_UNUSED,
+                GList            *events,
+                MsdRfkillManager *manager)
 {
 	GList *l;
         int value;
@@ -519,7 +519,7 @@ sync_wwan_enabled (MsdRfkillManager *manager)
 
 static void
 nm_signal (GDBusProxy *proxy,
-           char       *sender_name,
+           char       *sender_name G_GNUC_UNUSED,
            char       *signal_name,
            GVariant   *parameters,
            gpointer    user_data)
@@ -575,8 +575,8 @@ on_nm_proxy_gotten (GObject      *source,
 
 static void
 sync_wwan_interesting (GDBusObjectManager *object_manager,
-                       GDBusObject        *object,
-                       GDBusInterface     *interface,
+                       GDBusObject        *object G_GNUC_UNUSED,
+                       GDBusInterface     *interface G_GNUC_UNUSED,
                        gpointer            user_data)
 {
         MsdRfkillManager *manager = user_data;

--- a/plugins/smartcard/msd-smartcard-plugin.c
+++ b/plugins/smartcard/msd-smartcard-plugin.c
@@ -158,7 +158,7 @@ msd_smartcard_plugin_finalize (GObject *object)
 }
 
 static void
-smartcard_inserted_cb (MsdSmartcardManager *card_monitor,
+smartcard_inserted_cb (MsdSmartcardManager *card_monitor G_GNUC_UNUSED,
                        MsdSmartcard        *card,
                        MsdSmartcardPlugin  *plugin)
 {
@@ -229,7 +229,7 @@ process_smartcard_removal (MsdSmartcardPlugin *plugin)
 }
 
 static void
-smartcard_removed_cb (MsdSmartcardManager *card_monitor,
+smartcard_removed_cb (MsdSmartcardManager *card_monitor G_GNUC_UNUSED,
                       MsdSmartcard        *card,
                       MsdSmartcardPlugin  *plugin)
 {

--- a/plugins/sound/msd-sound-manager.c
+++ b/plugins/sound/msd-sound-manager.c
@@ -201,18 +201,18 @@ trigger_flush (MsdSoundManager *manager)
 }
 
 static void
-gsettings_notify_cb (GSettings *client,
-                     gchar *key,
+gsettings_notify_cb (GSettings *client G_GNUC_UNUSED,
+                     gchar *key G_GNUC_UNUSED,
                      MsdSoundManager *manager)
 {
         trigger_flush (manager);
 }
 
 static void
-file_monitor_changed_cb (GFileMonitor *monitor,
-                         GFile *file,
-                         GFile *other_file,
-                         GFileMonitorEvent event,
+file_monitor_changed_cb (GFileMonitor *monitor G_GNUC_UNUSED,
+                         GFile *file G_GNUC_UNUSED,
+                         GFile *other_file G_GNUC_UNUSED,
+                         GFileMonitorEvent event G_GNUC_UNUSED,
                          MsdSoundManager *manager)
 {
         g_debug ("Theme dir changed");

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -460,7 +460,9 @@ timeout_cb (gpointer data)
 }
 
 static void
-timeout_response_cb (GtkDialog *dialog, int response_id, gpointer data)
+timeout_response_cb (GtkDialog *dialog G_GNUC_UNUSED,
+                     int        response_id,
+                     gpointer   data)
 {
         TimeoutDialog *timeout = data;
 
@@ -1670,13 +1672,14 @@ run_display_capplet (GtkWidget *widget)
 }
 
 static void
-popup_menu_configure_display_cb (GtkMenuItem *item, gpointer data)
+popup_menu_configure_display_cb (GtkMenuItem *item, gpointer data G_GNUC_UNUSED)
 {
         run_display_capplet (GTK_WIDGET (item));
 }
 
 static void
-status_icon_popup_menu_selection_done_cb (GtkMenuShell *menu_shell, gpointer data)
+status_icon_popup_menu_selection_done_cb (GtkMenuShell *menu_shell G_GNUC_UNUSED,
+                                          gpointer      data)
 {
         MsdXrandrManager *manager = MSD_XRANDR_MANAGER (data);
         struct MsdXrandrManagerPrivate *priv = manager->priv;
@@ -1696,7 +1699,7 @@ status_icon_popup_menu_selection_done_cb (GtkMenuShell *menu_shell, gpointer dat
 #define OUTPUT_TITLE_ITEM_PADDING 4
 
 static void
-title_item_size_allocate_cb (GtkWidget *widget, GtkAllocation *allocation, gpointer data)
+title_item_size_allocate_cb (GtkWidget *widget, GtkAllocation *allocation, gpointer data G_GNUC_UNUSED)
 {
         /* When GtkMenu does size_request on its items, it asks them for their "toggle size",
          * which will be non-zero when there are check/radio items.  GtkMenu remembers
@@ -2325,7 +2328,8 @@ status_icon_popup_menu (MsdXrandrManager *manager, guint button, guint32 timesta
 }
 
 static void
-status_icon_activate_cb (GtkStatusIcon *status_icon, gpointer data)
+status_icon_activate_cb (GtkStatusIcon *status_icon G_GNUC_UNUSED,
+                         gpointer       data)
 {
         MsdXrandrManager *manager = MSD_XRANDR_MANAGER (data);
 
@@ -2334,7 +2338,10 @@ status_icon_activate_cb (GtkStatusIcon *status_icon, gpointer data)
 }
 
 static void
-status_icon_popup_menu_cb (GtkStatusIcon *status_icon, guint button, guint32 timestamp, gpointer data)
+status_icon_popup_menu_cb (GtkStatusIcon *status_icon G_GNUC_UNUSED,
+                           guint          button,
+                           guint32        timestamp,
+                           gpointer       data)
 {
         MsdXrandrManager *manager = MSD_XRANDR_MANAGER (data);
 
@@ -2391,7 +2398,7 @@ start_or_stop_icon (MsdXrandrManager *manager)
 }
 
 static void
-on_config_changed (GSettings        *settings,
+on_config_changed (GSettings        *settings G_GNUC_UNUSED,
                    gchar            *key,
                    MsdXrandrManager *manager)
 {

--- a/plugins/xrdb/msd-xrdb-manager.c
+++ b/plugins/xrdb/msd-xrdb-manager.c
@@ -473,8 +473,8 @@ apply_settings (MsdXrdbManager *manager,
 }
 
 static void
-theme_changed (GtkSettings    *settings,
-               GParamSpec     *pspec,
+theme_changed (GtkSettings    *settings G_GNUC_UNUSED,
+               GParamSpec     *pspec G_GNUC_UNUSED,
                MsdXrdbManager *manager)
 {
         apply_settings (manager, gtk_widget_get_style (manager->priv->widget));

--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -704,7 +704,7 @@ update_xft_settings (MateXSettingsManager *manager)
 }
 
 static void
-recalculate_scale_callback (GdkScreen            *screen,
+recalculate_scale_callback (GdkScreen            *screen G_GNUC_UNUSED,
                             MateXSettingsManager *manager)
 {
         int i;
@@ -721,8 +721,8 @@ recalculate_scale_callback (GdkScreen            *screen,
 }
 
 static void
-xft_callback (GSettings            *gsettings,
-              const gchar          *key,
+xft_callback (GSettings            *gsettings G_GNUC_UNUSED,
+              const gchar          *key G_GNUC_UNUSED,
               MateXSettingsManager *manager)
 {
         int i;


### PR DESCRIPTION
mark parameters as unused with `G_GNUC_UNUSED` called by `G_CALLBACK` inside `g_signal_connect`