### PR TITLE
mate-settings-plugin-info: unused parameter 'settings'

### DIFF
--- a/mate-settings-daemon/mate-settings-plugin-info.c
+++ b/mate-settings-daemon/mate-settings-plugin-info.c
@@ -266,11 +266,11 @@ mate_settings_plugin_info_fill_from_file (MateSettingsPluginInfo *info,
 }
 
 static void
-plugin_enabled_cb (GSettings              *settings G_GNUC_UNUSED,
+plugin_enabled_cb (GSettings              *settings,
                    gchar                  *key,
                    MateSettingsPluginInfo *info)
 {
-        if (g_settings_get_boolean (info->priv->settings, key)) {
+        if (g_settings_get_boolean (settings, key)) {
                 mate_settings_plugin_info_activate (info);
         } else {
                 mate_settings_plugin_info_deactivate (info);


### PR DESCRIPTION
```
mate-settings-plugin-info.c: In function 'plugin_enabled_cb':
mate-settings-plugin-info.c:269:44: warning: unused parameter 'settings' [-Wunused-parameter]
  269 | plugin_enabled_cb (GSettings              *settings,
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```
Test: disable/enable msd plugin
```
$ gsettings get org.mate.SettingsDaemon.plugins.housekeeping active
true
$ gsettings set org.mate.SettingsDaemon.plugins.housekeeping active false
```

![Screenshot at 2020-08-15 13-59-09](https://user-images.githubusercontent.com/10171411/90311840-b3099d80-deff-11ea-9c75-d26629622b63.png)
