### PR TITLE
main: Do not override detailed_signal for debugging

### DIFF
--- a/mate-settings-daemon/main.c
+++ b/mate-settings-daemon/main.c
@@ -445,10 +445,10 @@ parse_args (int *argc, char ***argv)
 }
 
 static void debug_changed (GSettings *settings,
-                           gchar     *key G_GNUC_UNUSED,
+                           gchar     *key,
                            gpointer   user_data G_GNUC_UNUSED)
 {
-        debug = g_settings_get_boolean (settings, DEBUG_KEY);
+        debug = g_settings_get_boolean (settings, key);
         if (debug) {
             g_warning ("Enable DEBUG");
             g_setenv ("G_MESSAGES_DEBUG", "all", FALSE);


### PR DESCRIPTION
Test: enable debugging
```
$ gsettings get org.mate.debug mate-settings-daemon
false
$ gsettings set org.mate.debug mate-settings-daemon true
```

![Screenshot at 2020-08-15 15-44-40](https://user-images.githubusercontent.com/10171411/90313635-65e0f800-df0e-11ea-8b3f-e3aa0674f863.png)
