### PR TITLE
Remove warning -Wshadow

### DIFF
--- a/plugins/clipboard/msd-clipboard-manager.c
+++ b/plugins/clipboard/msd-clipboard-manager.c
@@ -404,7 +404,6 @@ convert_clipboard_manager (MsdClipboardManager *manager,
         int           format;
         unsigned long nitems;
         unsigned long remaining;
-        Atom         *targets = NULL;
 
         display = gdk_display_get_default ();
 
@@ -415,6 +414,8 @@ convert_clipboard_manager (MsdClipboardManager *manager,
                          */
                         finish_selection_request (manager, xev, False);
                 } else {
+                        Atom *targets = NULL;
+
                         gdk_x11_display_error_trap_push (display);
 
                         clipboard_manager_watch_cb (manager,

--- a/plugins/housekeeping/msd-disk-space.c
+++ b/plugins/housekeeping/msd-disk-space.c
@@ -635,7 +635,7 @@ msd_ldsm_get_config (void)
 }
 
 static void
-msd_ldsm_update_config (GSettings *settings G_GNUC_UNUSED,
+msd_ldsm_update_config (GSettings *gsettings G_GNUC_UNUSED,
                         gchar *key G_GNUC_UNUSED,
                         gpointer user_data G_GNUC_UNUSED)
 {

--- a/plugins/keyboard/msd-keyboard-xkb.c
+++ b/plugins/keyboard/msd-keyboard-xkb.c
@@ -259,7 +259,9 @@ popup_menu_set_group (GtkMenuItem *item G_GNUC_UNUSED,
 }
 
 static void
-status_icon_popup_menu_cb (GtkStatusIcon * icon, guint button, guint time)
+status_icon_popup_menu_cb (GtkStatusIcon *status_icon,
+                           guint          button,
+                           guint          time)
 {
 	GtkWidget *toplevel;
 	GdkScreen *screen;
@@ -330,7 +332,7 @@ status_icon_popup_menu_cb (GtkStatusIcon * icon, guint button, guint time)
 
 	gtk_menu_popup (popup_menu, NULL, NULL,
 			gtk_status_icon_position_menu,
-			(gpointer) icon, button, time);
+			(gpointer) status_icon, button, time);
 }
 
 static void

--- a/plugins/mouse/msd-locate-pointer.c
+++ b/plugins/mouse/msd-locate-pointer.c
@@ -48,8 +48,6 @@ struct MsdLocatePointerData
   gdouble progress;
 };
 
-static MsdLocatePointerData *data = NULL;
-
 static void
 locate_pointer_paint (MsdLocatePointerData *data,
 		      cairo_t              *cr,
@@ -414,6 +412,7 @@ void
 msd_locate_pointer (GdkDisplay *display)
 {
   GdkScreen *screen = gdk_display_get_default_screen (display);
+  static MsdLocatePointerData *data = NULL;
 
   if (data == NULL)
     {


### PR DESCRIPTION
```
msd-clipboard-manager.c:472:22: warning: declaration of 'targets' shadows a previous local [-Wshadow]
  472 |                 Atom targets[3];
      |                      ^~~~~~~
--
msd-disk-space.c:638:36: warning: declaration of 'settings' shadows a global declaration [-Wshadow]
  638 | msd_ldsm_update_config (GSettings *settings ,
      |                         ~~~~~~~~~~~^~~~~~~~
--
msd-keyboard-xkb.c:262:44: warning: declaration of 'icon' shadows a global declaration [-Wshadow]
  262 | status_icon_popup_menu_cb (GtkStatusIcon * icon, guint button, guint time)
      |                            ~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:54:45: warning: declaration of 'data' shadows a global declaration [-Wshadow]
   54 | locate_pointer_paint (MsdLocatePointerData *data,
      |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:145:37: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  145 | update_shape (MsdLocatePointerData *data)
      |               ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:173:25: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  173 |   MsdLocatePointerData *data = (MsdLocatePointerData *) user_data;
      |                         ^~~~
--
msd-locate-pointer.c:240:43: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  240 |                     MsdLocatePointerData *data)
      |                     ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:256:25: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  256 |   MsdLocatePointerData *data = (MsdLocatePointerData *) user_data;
      |                         ^~~~
--
msd-locate-pointer.c:270:52: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  270 |                              MsdLocatePointerData *data)
      |                              ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:283:50: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  283 |                            MsdLocatePointerData *data)
      |                            ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msd-locate-pointer.c:328:25: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  328 |   MsdLocatePointerData *data = (MsdLocatePointerData *) user_data;
      |                         ^~~~
--
msd-locate-pointer.c:342:25: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  342 |   MsdLocatePointerData *data;
      |                         ^~~~
--
msd-locate-pointer.c:371:51: warning: declaration of 'data' shadows a global declaration [-Wshadow]
  371 | move_locate_pointer_window (MsdLocatePointerData *data,
      |                             ~~~~~~~~~~~~~~~~~~~~~~^~~~
```