### PR TITLE
mate-settings-daemon: Remove -Wconversion -Wsign-conversion -Wcast-function-type warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ dnl - Dependencies
 dnl ---------------------------------------------------------------------------
 
 DBUS_GLIB_REQUIRED_VERSION=0.74
-GLIB_REQUIRED_VERSION=2.50.0
+GLIB_REQUIRED_VERSION=2.58.0
 GIO_REQUIRED_VERSION=2.50.0
 GTK_REQUIRED_VERSION=3.22.0
 MATE_DESKTOP_REQUIRED_VERSION=1.25.0

--- a/mate-settings-daemon/main.c
+++ b/mate-settings-daemon/main.c
@@ -73,7 +73,7 @@ static gboolean
 timed_exit_cb (void)
 {
         gtk_main_quit ();
-        return FALSE;
+        return G_SOURCE_REMOVE;
 }
 
 static DBusGProxy *
@@ -547,7 +547,7 @@ main (int argc, char *argv[])
         }
 
         if (do_timed_exit) {
-                g_timeout_add_seconds (30, (GSourceFunc) timed_exit_cb, NULL);
+                g_timeout_add_seconds (30, G_SOURCE_FUNC (timed_exit_cb), NULL);
         }
 
         gtk_main ();

--- a/mate-settings-daemon/mate-settings-manager.c
+++ b/mate-settings-daemon/mate-settings-manager.c
@@ -124,13 +124,7 @@ static int
 compare_priority (MateSettingsPluginInfo *a,
                   MateSettingsPluginInfo *b)
 {
-        int prio_a;
-        int prio_b;
-
-        prio_a = mate_settings_plugin_info_get_priority (a);
-        prio_b = mate_settings_plugin_info_get_priority (b);
-
-        return prio_a - prio_b;
+        return mate_settings_plugin_info_get_priority (a) - mate_settings_plugin_info_get_priority (b);
 }
 
 static void

--- a/mate-settings-daemon/mate-settings-plugin-info.c
+++ b/mate-settings-daemon/mate-settings-plugin-info.c
@@ -53,20 +53,20 @@ struct MateSettingsPluginInfoPrivate
         char                    *copyright;
         char                    *website;
 
-        MateSettingsPlugin     *plugin;
+        MateSettingsPlugin      *plugin;
 
-        int                      enabled : 1;
-        int                      active : 1;
+        guint                    enabled : 1;
+        guint                    active : 1;
 
         /* A plugin is unavailable if it is not possible to activate it
            due to an error loading the plugin module */
-        int                      available : 1;
+        guint                    available : 1;
 
         guint                    enabled_notification_id;
 
         /* Priority determines the order in which plugins are started and
          * stopped. A lower number means higher priority. */
-        guint                    priority;
+        int                      priority;
 };
 
 
@@ -515,7 +515,7 @@ mate_settings_plugin_info_set_schema (MateSettingsPluginInfo *info,
 	g_return_if_fail (MATE_IS_SETTINGS_PLUGIN_INFO (info));
 
 	info->priv->settings = g_settings_new (schema);
-	info->priv->enabled = g_settings_get_boolean (info->priv->settings, "active");
+	info->priv->enabled = g_settings_get_boolean (info->priv->settings, "active") != FALSE;
 
 	priority = g_settings_get_int (info->priv->settings, "priority");
 	if (priority > 0)


### PR DESCRIPTION
-Wconversion 3
-Wsign-conversion 4

```
mate-settings-plugin-info.c:248:40: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  248 |                 info->priv->priority = priority;
      |                                        ^~~~~~~~
--
/usr/include/glib-2.0/glib/gmacros.h:808:14: warning: conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Wconversion]
  808 | #define TRUE (!FALSE)
      |              ^
--
/usr/include/glib-2.0/glib/gmacros.h:808:14: warning: conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Wconversion]
  808 | #define TRUE (!FALSE)
      |              ^
--
mate-settings-plugin-info.c:497:26: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  497 |         return info->priv->priority;
      |                ~~~~~~~~~~^~~~~~~~~~
--
mate-settings-plugin-info.c:506:32: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  506 |         info->priv->priority = priority;
      |                                ^~~~~~~~
--
mate-settings-plugin-info.c:518:24: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘signed char:1’ may change value [-Wconversion]
  518 |  info->priv->enabled = g_settings_get_boolean (info->priv->settings, "active");
      |                        ^~~~~~~~~~~~~~~~~~~~~~
mate-settings-plugin-info.c:522:26: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  522 |   info->priv->priority = priority;
      |                          ^~~~~~~~
```
-Wcast-function-type 1
```
main.c:550:44: warning: cast between incompatible function types from ‘gboolean (*)(void)’ {aka ‘int (*)(void)’} to ‘gboolean (*)(void *)’ {aka ‘int (*)(void *)’} [-Wcast-function-type]
  550 |                 g_timeout_add_seconds (30, (GSourceFunc) timed_exit_cb, NULL);
      |                                            ^
```

### bump glib required version

[G_SOURCE_FUNC](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#G-SOURCE-FUNC:CAPS) since glib 2.58