### PR TITLE
cppcheck warning: known condition is always true

### DIFF
--- a/plugins/common/msd-input-helper.c
+++ b/plugins/common/msd-input-helper.c
@@ -120,8 +120,8 @@ touchpad_is_present (void)
                         break;
                 }
         }
-        if (device_info != NULL)
-                XFreeDeviceList (device_info);
+
+        XFreeDeviceList (device_info);
 
         return retval;
 }

--- a/plugins/common/msd-keygrab.c
+++ b/plugins/common/msd-keygrab.c
@@ -240,7 +240,6 @@ match_key (Key *key, XEvent *event)
 	}
 
 	/* The key we passed doesn't have a keysym, so try with just the keycode */
-        return (key != NULL
-                && key->state == (event->xkey.state & msd_used_mods)
+        return (key->state == (event->xkey.state & msd_used_mods)
                 && key_uses_keycode (key, event->xkey.keycode));
 }

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -2050,11 +2050,10 @@ mirror_outputs_cb(GtkCheckMenuItem *item, gpointer data)
         struct MsdXrandrManagerPrivate *priv = manager->priv;
         MateRRScreen *screen = priv->rw_screen;
 
-        if (gtk_check_menu_item_get_active(item)){
-
+        if (gtk_check_menu_item_get_active (item)) {
                 MateRRConfig *config;
-                config = make_clone_setup (screen);
-                if (!config || config == NULL){
+
+                if ((config = make_clone_setup (screen)) == NULL) {
                         error_message (manager, _("Mirroring outputs not supported"), NULL, NULL);
                 }
 


### PR DESCRIPTION
```
 plugins/common/msd-input-helper.c:123:25: style: Condition 'device_info!=NULL' is always true [knownConditionTrueFalse]
         if (device_info != NULL)
                         ^
 plugins/common/msd-input-helper.c:111:25: note: Assuming that condition 'device_info==NULL' is not redundant
         if (device_info == NULL)
                         ^
 plugins/common/msd-input-helper.c:123:25: note: Condition 'device_info!=NULL' is always true
         if (device_info != NULL)
                         ^
```
```
 plugins/xrandr/msd-xrandr-manager.c:2057:39: style: Condition 'config==NULL' is always false [knownConditionTrueFalse]
                 if (!config || config == NULL){
                                       ^
 plugins/xrandr/msd-xrandr-manager.c:2057:21: note: Assuming that condition '!config' is not redundant
                 if (!config || config == NULL){
                     ^
 plugins/xrandr/msd-xrandr-manager.c:2057:39: note: Condition 'config==NULL' is always false
                 if (!config || config == NULL){
                                       ^
 plugins/xrandr/msd-xrandr-manager.c:2057:29: style: Same expression on both sides of '||' because '!config' and 'config==NULL' represent the same value. [knownConditionTrueFalse]
                 if (!config || config == NULL){
                             ^
```
```
plugins/common/msd-keygrab.c:243:21: style: Condition 'key!=NULL' is always true [knownConditionTrueFalse]
        return (key != NULL
                    ^
plugins/common/msd-keygrab.c:212:10: note: Assuming that condition 'key==NULL' is not redundant
 if (key == NULL)
         ^
plugins/common/msd-keygrab.c:225:42: note: Assuming condition is false
 if (gdk_keymap_translate_keyboard_state (gdk_keymap_get_for_display (gdk_display_get_default ()), event->xkey.keycode,
                                         ^
plugins/common/msd-keygrab.c:243:21: note: Condition 'key!=NULL' is always true
        return (key != NULL
                    ^
```