### PR TITLE
cppcheck warning: null pointer redundant check

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-manager.c
@@ -202,8 +202,7 @@ get_xkb_desc_rec (MsdA11yKeyboardManager *manager)
         }
         gdk_x11_display_error_trap_pop_ignored (display);
 
-        g_return_val_if_fail (desc != NULL, NULL);
-        g_return_val_if_fail (desc->ctrls != NULL, NULL);
+        g_return_val_if_fail (desc != NULL && desc->ctrls != NULL, NULL);
         g_return_val_if_fail (status == Success, NULL);
 
         return desc;


### PR DESCRIPTION
```
plugins/a11y-keyboard/msd-a11y-keyboard-manager.c:206:31: warning: Either the condition 'desc!=NULL' is redundant or there is possible null pointer dereference: desc. [nullPointerRedundantCheck]
        g_return_val_if_fail (desc->ctrls != NULL, NULL);
                              ^
plugins/a11y-keyboard/msd-a11y-keyboard-manager.c:199:18: note: Assuming that condition 'desc!=NULL' is not redundant
        if (desc != NULL) {
                 ^
plugins/a11y-keyboard/msd-a11y-keyboard-manager.c:206:31: note: Null pointer dereference
        g_return_val_if_fail (desc->ctrls != NULL, NULL);
                              ^
```