### PR TITLE
cppcheck warning: Variable is assigned a value that is never used

### DIFF
--- a/plugins/keyboard/msd-keyboard-manager.c
+++ b/plugins/keyboard/msd-keyboard-manager.c
@@ -201,8 +201,6 @@ apply_settings (GSettings          *settings,
         XKeyboardControl kbdcontrol;
         gboolean         repeat;
         gboolean         click;
-        int              rate;
-        int              delay;
         int              click_volume;
         int              bell_volume;
         int              bell_pitch;
@@ -215,8 +213,6 @@ apply_settings (GSettings          *settings,
 
         repeat        = g_settings_get_boolean  (settings, KEY_REPEAT);
         click         = g_settings_get_boolean  (settings, KEY_CLICK);
-        rate          = g_settings_get_int   (settings, KEY_RATE);
-        delay         = g_settings_get_int   (settings, KEY_DELAY);
         click_volume  = g_settings_get_int   (settings, KEY_CLICK_VOLUME);
         bell_pitch    = g_settings_get_int   (settings, KEY_BELL_PITCH);
         bell_duration = g_settings_get_int   (settings, KEY_BELL_DURATION);
@@ -233,8 +229,9 @@ apply_settings (GSettings          *settings,
                 XAutoRepeatOn (GDK_DISPLAY_XDISPLAY (display));
                 /* Use XKB in preference */
 #ifdef HAVE_X11_EXTENSIONS_XKB_H
-                rate_set = xkb_set_keyboard_autorepeat_rate (delay, rate);
-#endif
+                rate_set = xkb_set_keyboard_autorepeat_rate (g_settings_get_int (settings, KEY_DELAY),
+                                                             g_settings_get_int (settings, KEY_RATE));
+#endif /* HAVE_X11_EXTENSIONS_XKB_H */
                 if (!rate_set)
                         g_warning ("Neither XKeyboard not Xfree86's keyboard extensions are available,\n"
                                    "no way to support keyboard autorepeat rate settings");

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -600,7 +600,6 @@ do_eject_action (MsdMediaKeysManager *manager)
                         continue;
                 if (score < SCORE_HAS_MEDIA) {
                         fav_drive = drive;
-                        score = SCORE_HAS_MEDIA;
                         break;
                 }
         }

--- a/plugins/xrandr/msd-xrandr-manager.c
+++ b/plugins/xrandr/msd-xrandr-manager.c
@@ -785,7 +785,7 @@ find_best_mode (MateRROutput *output)
         MateRRMode *preferred;
         MateRRMode **modes;
         int best_size;
-        int best_width, best_height, best_rate;
+        int best_rate;
         int i;
         MateRRMode *best_mode;
 
@@ -797,7 +797,7 @@ find_best_mode (MateRROutput *output)
         if (!modes)
                 return NULL;
 
-        best_size = best_width = best_height = best_rate = 0;
+        best_size = best_rate = 0;
         best_mode = NULL;
 
         for (i = 0; modes[i] != NULL; i++) {
@@ -812,8 +812,6 @@ find_best_mode (MateRROutput *output)
 
                 if (size > best_size) {
                         best_size   = size;
-                        best_width  = w;
-                        best_height = h;
                         best_rate   = r;
                         best_mode   = modes[i];
                 } else if (size == best_size) {


### PR DESCRIPTION
```
plugins/keyboard/msd-keyboard-manager.c:218:23: style: Variable 'rate' is assigned a value that is never used. [unreadVariable]
        rate          = g_settings_get_int   (settings, KEY_RATE);
                      ^
plugins/keyboard/msd-keyboard-manager.c:219:23: style: Variable 'delay' is assigned a value that is never used. [unreadVariable]
        delay         = g_settings_get_int   (settings, KEY_DELAY);
                      ^
plugins/media-keys/msd-media-keys-manager.c:603:31: style: Variable 'score' is assigned a value that is never used. [unreadVariable]
                        score = SCORE_HAS_MEDIA;
                              ^
plugins/xrandr/msd-xrandr-manager.c:815:37: style: Variable 'best_width' is assigned a value that is never used. [unreadVariable]
                        best_width  = w;
                                    ^
plugins/xrandr/msd-xrandr-manager.c:816:37: style: Variable 'best_height' is assigned a value that is never used. [unreadVariable]
                        best_height = h;
                                    ^
```