### PR TITLE
cppcheck warning: struct member is never used

### DIFF
--- a/plugins/sound/msd-sound-manager.c
+++ b/plugins/sound/msd-sound-manager.c
@@ -45,8 +45,10 @@
 
 struct MsdSoundManagerPrivate
 {
+#ifdef HAVE_PULSE
         GSettings *settings;
         GList* monitors;
+#endif /* HAVE_PULSE */
         guint timeout;
 };
 


### PR DESCRIPTION
```
plugins/sound/msd-sound-manager.c:48:20: style: struct member 'MsdSoundManagerPrivate::settings' is never used. [unusedStructMember]
        GSettings *settings;
                   ^
plugins/sound/msd-sound-manager.c:49:16: style: struct member 'MsdSoundManagerPrivate::monitors' is never used. [unusedStructMember]
        GList* monitors;
               ^
```