### PR TITLE
media-keys: memory leak

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -616,7 +616,7 @@ do_eject_action (MsdMediaKeysManager *manager)
         if (fav_drive != NULL)
                 fav_drive = g_object_ref (fav_drive);
 
-        g_list_foreach (drives, (GFunc) g_object_unref, NULL);
+        g_list_free_full (drives, g_object_unref);
         if (fav_drive == NULL)
                 return;
 


### PR DESCRIPTION
> The returned list should be freed with g_list_free(), after its elements have been unreffed with g_object_unref().

https://developer.gnome.org/gio/stable/GVolumeMonitor.html#g-volume-monitor-get-connected-drives