### PR TITLE
housekeeping: Remove warning -Wcast-function-type

### DIFF
--- a/plugins/housekeeping/msd-housekeeping-manager.c
+++ b/plugins/housekeeping/msd-housekeeping-manager.c
@@ -200,8 +200,7 @@ purge_thumbnail_cache (MsdHousekeepingManager *manager)
                 }
         }
 
-        g_list_foreach (files, (GFunc) thumb_data_free, NULL);
-        g_list_free (files);
+        g_list_free_full (files, thumb_data_free);
         g_date_time_unref (purge_data.now);
 }
 


### PR DESCRIPTION
```
msd-housekeeping-manager.c: In function ‘purge_thumbnail_cache’:
msd-housekeeping-manager.c:203:32: warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  203 |         g_list_foreach (files, (GFunc) thumb_data_free, NULL);
      |                                ^
```