### PR TITLE
media-keys: Remove conversion warnings

### DIFF
--- a/plugins/media-keys/msd-media-keys-window.c
+++ b/plugins/media-keys/msd-media-keys-window.c
@@ -43,7 +43,7 @@ struct MsdMediaKeysWindowPrivate
         guint                    volume_muted : 1;
         guint                    mic_muted : 1;
         guint                    is_mic :1;
-        int                      volume_level;
+        guint                    volume_level;
 
         GtkImage                *image;
         GtkWidget               *progress;
@@ -223,7 +223,7 @@ msd_media_keys_window_set_volume_muted (MsdMediaKeysWindow *window,
         g_return_if_fail (MSD_IS_MEDIA_KEYS_WINDOW (window));
 
         if (window->priv->volume_muted != muted) {
-                window->priv->volume_muted = muted;
+                window->priv->volume_muted = muted != FALSE;
                 volume_muted_changed (window);
         }
         window->priv->is_mic = FALSE;
@@ -236,7 +236,7 @@ msd_media_keys_window_set_mic_muted (MsdMediaKeysWindow *window,
         g_return_if_fail (MSD_IS_MEDIA_KEYS_WINDOW (window));
 
         if (window->priv->mic_muted != muted) {
-                window->priv->mic_muted = muted;
+                window->priv->mic_muted = muted != FALSE;
                 mic_muted_changed (window);
         }
         window->priv->is_mic = TRUE;
@@ -244,7 +244,7 @@ msd_media_keys_window_set_mic_muted (MsdMediaKeysWindow *window,
 
 void
 msd_media_keys_window_set_volume_level (MsdMediaKeysWindow *window,
-                                        int                 level)
+                                        guint               level)
 {
         g_return_if_fail (MSD_IS_MEDIA_KEYS_WINDOW (window));
 
@@ -284,26 +284,26 @@ draw_eject (cairo_t *cr,
             double   width,
             double   height)
 {
-        int box_height;
-        int tri_height;
-        int separation;
+        double box_height;
+        double tri_height;
+        double separation;
 
         box_height = height * 0.2;
-        separation = box_height / 3;
+        separation = box_height / 3.0;
         tri_height = height - box_height - separation;
 
         cairo_rectangle (cr, _x0, _y0 + height - box_height, width, box_height);
 
         cairo_move_to (cr, _x0, _y0 + tri_height);
-        cairo_rel_line_to (cr, width, 0);
-        cairo_rel_line_to (cr, -width / 2, -tri_height);
-        cairo_rel_line_to (cr, -width / 2, tri_height);
+        cairo_rel_line_to (cr, width, 0.0);
+        cairo_rel_line_to (cr, -width * 0.5, -tri_height);
+        cairo_rel_line_to (cr, -width * 0.5, tri_height);
         cairo_close_path (cr);
         cairo_set_source_rgba (cr, 1.0, 1.0, 1.0, MSD_OSD_WINDOW_FG_ALPHA);
         cairo_fill_preserve (cr);
 
-        cairo_set_source_rgba (cr, 0.6, 0.6, 0.6, MSD_OSD_WINDOW_FG_ALPHA / 2);
-        cairo_set_line_width (cr, 2);
+        cairo_set_source_rgba (cr, 0.6, 0.6, 0.6, MSD_OSD_WINDOW_FG_ALPHA * 0.5);
+        cairo_set_line_width (cr, 2.0);
         cairo_stroke (cr);
 }
 
@@ -418,7 +418,7 @@ render_speaker (MsdMediaKeysWindow *window,
 {
         GdkPixbuf         *pixbuf;
         int                icon_size;
-        int                n;
+        guint              n;
         static const char *icon_names[] = {
                 "audio-volume-muted",
                 "audio-volume-low",
@@ -605,7 +605,7 @@ draw_action_volume (MsdMediaKeysWindow *window,
                         wave_y0 = speaker_cy;
                         wave_radius = icon_box_width / 2;
 
-                        draw_waves (cr, wave_x0, wave_y0, wave_radius, window->priv->volume_level);
+                        draw_waves (cr, wave_x0, wave_y0, wave_radius, (int) window->priv->volume_level);
                 } else {
                         /* draw 'mute' cross */
                         double cross_x0;

--- a/plugins/media-keys/msd-media-keys-window.h
+++ b/plugins/media-keys/msd-media-keys-window.h
@@ -70,7 +70,7 @@ void                  msd_media_keys_window_set_mic_muted     (MsdMediaKeysWindo
 void                  msd_media_keys_window_set_volume_muted  (MsdMediaKeysWindow      *window,
                                                                gboolean                 muted);
 void                  msd_media_keys_window_set_volume_level  (MsdMediaKeysWindow      *window,
-                                                               int                      level);
+                                                               guint                    level);
 gboolean              msd_media_keys_window_is_valid          (MsdMediaKeysWindow      *window);
 
 #ifdef __cplusplus


### PR DESCRIPTION
```
msd-media-keys-manager.c: In function ‘update_dialog’:
msd-media-keys-manager.c:680:49: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  680 |                                                 volume);
      |                                                 ^~~~~~
msd-media-keys-manager.c: In function ‘do_sound_action’:
msd-media-keys-manager.c:726:23: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  726 |         volume_step = g_settings_get_int (manager->priv->settings, "volume-step");
      |                       ^~~~~~~~~~~~~~~~~~
msd-media-keys-manager.c:729:31: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint32’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  729 |                 volume_step = g_variant_get_int32 (variant);
      |                               ^~~~~~~~~~~~~~~~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_volume_muted’:
msd-media-keys-window.c:226:46: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  226 |                 window->priv->volume_muted = muted;
      |                                              ^~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_mic_muted’:
msd-media-keys-window.c:239:43: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  239 |                 window->priv->mic_muted = muted;
      |                                           ^~~~~
msd-media-keys-window.c: In function ‘draw_eject’:
msd-media-keys-window.c:291:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  291 |         box_height = height * 0.2;
      |                      ^~~~~~
msd-media-keys-window.c:293:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  293 |         tri_height = height - box_height - separation;
      |                      ^~~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_volume_muted’:
msd-media-keys-window.c:226:46: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  226 |                 window->priv->volume_muted = muted;
      |                                              ^~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_mic_muted’:
msd-media-keys-window.c:239:43: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  239 |                 window->priv->mic_muted = muted;
      |                                           ^~~~~
msd-media-keys-window.c: In function ‘draw_eject’:
msd-media-keys-window.c:291:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  291 |         box_height = height * 0.2;
      |                      ^~~~~~
msd-media-keys-window.c:293:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  293 |         tri_height = height - box_height - separation;
      |                      ^~~~~~
msd-media-keys-manager.c: In function ‘update_dialog’:
msd-media-keys-manager.c:680:49: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  680 |                                                 volume);
      |                                                 ^~~~~~
msd-media-keys-manager.c: In function ‘do_sound_action’:
msd-media-keys-manager.c:726:23: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  726 |         volume_step = g_settings_get_int (manager->priv->settings, "volume-step");
      |                       ^~~~~~~~~~~~~~~~~~
msd-media-keys-manager.c:729:31: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint32’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  729 |                 volume_step = g_variant_get_int32 (variant);
      |                               ^~~~~~~~~~~~~~~~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_volume_muted’:
msd-media-keys-window.c:226:46: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  226 |                 window->priv->volume_muted = muted;
      |                                              ^~~~~
msd-media-keys-window.c: In function ‘msd_media_keys_window_set_mic_muted’:
msd-media-keys-window.c:239:43: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  239 |                 window->priv->mic_muted = muted;
      |                                           ^~~~~
msd-media-keys-window.c: In function ‘draw_eject’:
msd-media-keys-window.c:291:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  291 |         box_height = height * 0.2;
      |                      ^~~~~~
msd-media-keys-window.c:293:22: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
  293 |         tri_height = height - box_height - separation;
      |                      ^~~~~~
```