### PR TITLE
rfkill: g_memdup is dreprecated from glib 2.68

### DIFF
--- a/plugins/rfkill/rfkill-glib.c
+++ b/plugins/rfkill/rfkill-glib.c
@@ -357,7 +357,11 @@ event_cb (GIOChannel   *source,
 
 			print_event (&event);
 
+#if GLIB_CHECK_VERSION (2, 68, 0)
+			event_ptr = g_memdup2 (&event, sizeof(event));
+#else
 			event_ptr = g_memdup (&event, sizeof(event));
+#endif
 			events = g_list_prepend (events, event_ptr);
 
 			status = g_io_channel_read_chars (source,
@@ -440,7 +444,11 @@ cc_rfkill_glib_open (CcRfkillGlib *rfkill)
 			 type_to_string (event.type),
 			 event.idx, event.soft, event.hard);
 
+#if GLIB_CHECK_VERSION (2, 68, 0)
+		event_ptr = g_memdup2 (&event, sizeof(event));
+#else
 		event_ptr = g_memdup (&event, sizeof(event));
+#endif
 		events = g_list_prepend (events, event_ptr);
 	}
 


### PR DESCRIPTION
```
rfkill-glib.c:360:25: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  360 |                         event_ptr = g_memdup (&event, sizeof(event));
      |                         ^~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:82,
                 from rfkill-glib.c:35:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
```
```
rfkill-glib.c:443:17: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  443 |                 event_ptr = g_memdup (&event, sizeof(event));
      |                 ^~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:82,
                 from rfkill-glib.c:35:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
```