### PR TITLE
xsettings: Set Xft.dpi in X resources to scaled_dpi

### DIFF
--- a/plugins/xsettings/msd-xsettings-manager.c
+++ b/plugins/xsettings/msd-xsettings-manager.c
@@ -660,8 +660,8 @@ xft_settings_set_xresources (MateXftSettings *settings)
 
         g_debug("xft_settings_set_xresources: orig res '%s'", add_string->str);
 
-        update_property (add_string, "Xft.dpi",
-                                g_ascii_dtostr (dpibuf, sizeof (dpibuf), (double) settings->dpi / 1024.0));
+        g_snprintf (dpibuf, sizeof (dpibuf), "%d", (int) (settings->scaled_dpi / 1024.0 + 0.5));
+        update_property (add_string, "Xft.dpi", dpibuf);
         update_property (add_string, "Xft.antialias",
                                 settings->antialias ? "1" : "0");
         update_property (add_string, "Xft.hinting",


### PR DESCRIPTION
This makes it match Xft/DPI in XSETTINGS. Applications relying on Xft.dpi
on HiDPI screens will now work correctly.

Behavior is now consistent with GNOME, relevant commits from gsd:
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/047f030235972fdab5e15aff484006caf914216a
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/25c7cc703118c69b224acf9c4f7af09a31f50a34