### PR TITLE
xrdb: wrong type field in printf format string

### DIFF
--- a/plugins/xrdb/msd-xrdb-manager.c
+++ b/plugins/xrdb/msd-xrdb-manager.c
@@ -70,9 +70,9 @@ append_color_define (GString        *string,
         g_string_append_printf (string,
                                 "#define %s #%2.2hx%2.2hx%2.2hx\n",
                                 name,
-                                color->red>>8,
-                                color->green>>8,
-                                color->blue>>8);
+                                (unsigned short) (color->red>>8),
+                                (unsigned short) (color->green>>8),
+                                (unsigned short) (color->blue>>8));
 }
 
 static GdkColor*


### PR DESCRIPTION
```
msd-xrdb-manager.c:73:33: warning: format specifies type 'unsigned short' but the argument has type 'int' [-Wformat]
                                color->red>>8,
                                ^~~~~~~~~~~~~
msd-xrdb-manager.c:74:33: warning: format specifies type 'unsigned short' but the argument has type 'int' [-Wformat]
                                color->green>>8,
                                ^~~~~~~~~~~~~~~
msd-xrdb-manager.c:75:33: warning: format specifies type 'unsigned short' but the argument has type 'int' [-Wformat]
                                color->blue>>8);
                                ^~~~~~~~~~~~~~
```