### PR TITLE
datetime: fix memory leak

### DIFF
--- a/plugins/datetime/msd-datetime-mechanism.c
+++ b/plugins/datetime/msd-datetime-mechanism.c
@@ -225,7 +225,7 @@ msd_datetime_mechanism_new (void)
 static gboolean
 _check_polkit_for_action (MsdDatetimeMechanism *mechanism, DBusGMethodInvocation *context, const char *action)
 {
-        const char *sender;
+        char *sender;
         GError *error;
         PolkitSubject *subject;
         PolkitAuthorizationResult *result;
@@ -235,6 +235,7 @@ _check_polkit_for_action (MsdDatetimeMechanism *mechanism, DBusGMethodInvocation
         /* Check that caller is privileged */
         sender = dbus_g_method_get_sender (context);
         subject = polkit_system_bus_name_new (sender);
+        g_free (sender);
 
         result = polkit_authority_check_authorization_sync (mechanism->priv->auth,
                                                             subject,
@@ -581,7 +582,7 @@ check_can_do (MsdDatetimeMechanism  *mechanism,
               const char            *action,
               DBusGMethodInvocation *context)
 {
-        const char *sender;
+        char *sender;
         PolkitSubject *subject;
         PolkitAuthorizationResult *result;
         GError *error;
@@ -589,6 +590,7 @@ check_can_do (MsdDatetimeMechanism  *mechanism,
         /* Check that caller is privileged */
         sender = dbus_g_method_get_sender (context);
         subject = polkit_system_bus_name_new (sender);
+        g_free (sender);
 
         error = NULL;
         result = polkit_authority_check_authorization_sync (mechanism->priv->auth,


### PR DESCRIPTION
```
CC=gcc CFLAGS="-ggdb3 -O0 -fsanitize=address" LDFLAGS="-fsanitize=address"  ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
```
LeakSanitizer: detected memory leaks
Direct leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7f7e2094393f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f7e1f867b7f in g_malloc ../glib/gmem.c:106
    #2 0x7f7e1f867ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f7e1f88a1a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x4068b5 in check_can_do /home/robert/builddir.gcc/mate-settings-daemon/plugins/datetime/msd-datetime-mechanism.c:596
    #5 0x406ae0 in msd_datetime_mechanism_can_set_time /home/robert/builddir.gcc/mate-settings-daemon/plugins/datetime/msd-datetime-mechanism.c:633
    #6 0x7f7e1f9782bf in g_cclosure_marshal_VOID__POINTER ../gobject/gmarshal.c:1744
    #7 0x7f7e1fa25fe3 in object_registration_message (/lib64/libdbus-glib-1.so.2+0xffe3)
    #8 0x6040000031cf  (<unknown module>)
SUMMARY: AddressSanitizer: 7 byte(s) leaked in 1 allocation(s).
```