### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/mate-settings-daemon/main.c
+++ b/mate-settings-daemon/main.c
@@ -67,7 +67,7 @@ static GOptionEntry entries[] = {
         { "replace", 0, 0, G_OPTION_ARG_NONE, &replace, N_("Replace the current daemon"), NULL },
         { "no-daemon", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &no_daemon, N_("Don't become a daemon"), NULL },
         { "timed-exit", 0, 0, G_OPTION_ARG_NONE, &do_timed_exit, N_("Exit after a time (for debugging)"), NULL },
-        { NULL }
+        { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static gboolean

--- a/plugins/rfkill/msd-rfkill-manager.c
+++ b/plugins/rfkill/msd-rfkill-manager.c
@@ -462,7 +462,8 @@ static const GDBusInterfaceVTable interface_vtable =
 {
         NULL,
         handle_get_property,
-        handle_set_property
+        handle_set_property,
+        { 0 }
 };
 
 static void


### PR DESCRIPTION
```
main.c:70:16: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
msd-rfkill-manager.c:466:1: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
};
^
```