### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/plugins/common/msd-osd-window.c
+++ b/plugins/common/msd-osd-window.c
@@ -441,7 +441,7 @@ msd_osd_window_init (MsdOsdWindow *window)
 
         screen = gtk_widget_get_screen (GTK_WIDGET (window));
 
-        window->priv->is_composited = gdk_screen_is_composited (screen);
+        window->priv->is_composited = (gdk_screen_is_composited (screen) != FALSE);
         window->priv->scale_factor = gtk_widget_get_scale_factor (GTK_WIDGET (window));
 
         if (window->priv->is_composited) {

--- a/plugins/mouse/msd-timeline.c
+++ b/plugins/mouse/msd-timeline.c
@@ -646,7 +646,7 @@ msd_timeline_set_loop (MsdTimeline *timeline,
   g_return_if_fail (MSD_IS_TIMELINE (timeline));
 
   priv = msd_timeline_get_instance_private (timeline);
-  priv->loop = loop;
+  priv->loop = (loop != FALSE);
 
   g_object_notify (G_OBJECT (timeline), "loop");
 }


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
msd-osd-window.c:444:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->is_composited = gdk_screen_is_composited (screen);
                                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
msd-timeline.c:649:16: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
  priv->loop = loop;
             ~ ^~~~
```