### PR TITLE
use docker-build from mate-dev test-branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - gh-pages
 
 before_install:
-  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/test-glibc-update/travis/docker-build
   - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/gen-index.sh
   - chmod +x docker-build gen-index
 


### PR DESCRIPTION
This PR is for testing https://github.com/mate-desktop/mate-dev-scripts/pull/36
Debian build at travis CI should run fine here.
After https://github.com/mate-desktop/mate-dev-scripts/pull/36 is merged this PR can be closed, do not merge it.