### PR TITLE
[plugins] Fix build \w clang 16

### DIFF
--- a/plugins/a11y-keyboard/msd-a11y-keyboard-atspi.c
+++ b/plugins/a11y-keyboard/msd-a11y-keyboard-atspi.c
@@ -128,7 +128,7 @@ msd_a11y_keyboard_atspi_start (MsdA11yKeyboardAtspi *self)
         /* init AT-SPI if needed */
         atspi_init ();
 
-        self->listener = atspi_device_listener_new (on_key_press_event,
+        self->listener = atspi_device_listener_new ((AtspiDeviceListenerCB)on_key_press_event,
                                                     self, NULL);
 #endif
         register_deregister_events (self, TRUE);


### PR DESCRIPTION
Clang 16 has made -Wincompatible-function-pointer-types and other warnigns enabled by default. Hence we're getting erros such as:

```
msd-a11y-keyboard-atspi.c:131:53: error: incompatible function pointer types passing
      'gboolean (const AtspiDeviceEvent *, void *)' (aka 'int (const struct _AtspiDeviceEvent *, void *)') to
      parameter of type 'AtspiDeviceListenerCB' (aka 'int (*)(struct _AtspiDeviceEvent *, void *)')
      [-Wincompatible-function-pointer-types]
        self->listener = atspi_device_listener_new (on_key_press_event,
                                                    ^~~~~~~~~~~~~~~~~~
```