### PR TITLE
Gdbus rfkill

### DIFF
--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -1409,7 +1409,7 @@ rfkill_appeared_cb (GDBusConnection *connection,
 
         g_dbus_proxy_new_for_bus (G_BUS_TYPE_SESSION,
                                   0, NULL,
-                                  "org.mate.SettingsDaemon.Rfkill",
+                                  "org.mate.SettingsDaemon",
                                   "/org/mate/SettingsDaemon/Rfkill",
                                   "org.mate.SettingsDaemon.Rfkill",
                                   manager->priv->rfkill_cancellable,

--- a/plugins/rfkill/msd-rfkill-manager.c
+++ b/plugins/rfkill/msd-rfkill-manager.c
@@ -66,9 +66,8 @@ struct MsdRfkillManagerPrivate
 #define MSD_RFKILL_DBUS_PATH MSD_DBUS_PATH "/Rfkill"
 
 static const gchar introspection_xml[] =
-"<node>"
+"<node name='/org/mate/SettingsDaemon/Rfkill'>"
 "  <interface name='org.mate.SettingsDaemon.Rfkill'>"
-"    <annotation name='org.freedesktop.DBus.GLib.CSymbol' value='msd_rfkill_manager'/>"
 "    <property name='AirplaneMode' type='b' access='readwrite'/>"
 "    <property name='HardwareAirplaneMode' type='b' access='read'/>"
 "    <property name='HasAirplaneMode' type='b' access='read'/>"
@@ -493,7 +492,7 @@ on_bus_gotten (GObject               *source_object,
 
         manager->priv->name_id = g_bus_own_name_on_connection (connection,
                                                                MSD_RFKILL_DBUS_NAME,
-                                                               G_BUS_NAME_OWNER_FLAGS_NONE,
+                                                               G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT,
                                                                NULL,
                                                                NULL,
                                                                NULL,

--- a/plugins/rfkill/msd-rfkill-manager.c
+++ b/plugins/rfkill/msd-rfkill-manager.c
@@ -491,7 +491,7 @@ on_bus_gotten (GObject               *source_object,
                                            NULL);
 
         manager->priv->name_id = g_bus_own_name_on_connection (connection,
-                                                               MSD_RFKILL_DBUS_NAME,
+                                                               MSD_DBUS_NAME,
                                                                G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT,
                                                                NULL,
                                                                NULL,


### PR DESCRIPTION
1. rename dbus name to "org.mate.SettingsDaemon", now there is only one dbus name called "org.mate.SettingsDaemon", you  can see the difference using `d-feet`.
2. allow `mate-settings-daemon --replace`