### PR TITLE
plugins: fix undefined references

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ PKG_CHECK_MODULES(SETTINGS_PLUGIN,
 	gio-2.0 >= $GIO_REQUIRED_VERSION
 )
 
-MSD_PLUGIN_LDFLAGS="-export_dynamic -module -avoid-version -no-undefined"
+MSD_PLUGIN_LDFLAGS="-export_dynamic -module -avoid-version"
 case $host_os in
   darwin*)
     MSD_PLUGIN_LDFLAGS="${MSD_PLUGIN_LDFLAGS} -Wl,-bundle_loader,\$(top_builddir)/mate-settings-daemon/mate-settings-daemon"

--- a/mate-settings-daemon/Makefile.am
+++ b/mate-settings-daemon/Makefile.am
@@ -21,7 +21,7 @@ libmsd_profile_la_SOURCES =		\
 	$(NULL)
 
 libmsd_profile_la_CPPFLAGS = 		\
-	$(AM_CPPFLAGS)
+	$(AM_CPPFLAGS)			\
 	$(DISABLE_DEPRECATED_CFLAGS)	\
 	$(NULL)
 

--- a/plugins/a11y-keyboard/Makefile.am
+++ b/plugins/a11y-keyboard/Makefile.am
@@ -66,6 +66,8 @@ liba11y_keyboard_la_LDFLAGS = 		\
 liba11y_keyboard_la_LIBADD  = 		\
 	$(SETTINGS_PLUGIN_LIBS)		\
 	$(LIBNOTIFY_LIBS)		\
+	$(X11_LIBS)			\
+	$(XINPUT_LIBS)			\
 	$(NULL)
 
 if HAVE_LIBATSPI

--- a/plugins/background/Makefile.am
+++ b/plugins/background/Makefile.am
@@ -58,6 +58,7 @@ libbackground_la_LDFLAGS = 		\
 libbackground_la_LIBADD  = 		\
 	$(SETTINGS_PLUGIN_LIBS)		\
 	$(MATE_DESKTOP_LIBS)		\
+	$(X11_LIBS)			\
 	$(NULL)
 
 plugin_in_files = 		\

--- a/plugins/clipboard/Makefile.am
+++ b/plugins/clipboard/Makefile.am
@@ -31,6 +31,8 @@ libclipboard_la_LDFLAGS = 	\
 
 libclipboard_la_LIBADD  = 	\
 	$(SETTINGS_PLUGIN_LIBS)	\
+	$(X11_LIBS)		\
+	$(XINPUT_LIBS)		\
 	$(NULL)
 
 plugin_in_files = 		\

--- a/plugins/keyboard/Makefile.am
+++ b/plugins/keyboard/Makefile.am
@@ -46,6 +46,8 @@ libkeyboard_la_LIBADD  = 	\
 	$(SETTINGS_PLUGIN_LIBS)	\
 	$(LIBMATEKBDUI_LIBS)	\
 	$(MATE_DESKTOP_LIBS)	\
+	$(X11_LIBS)		\
+	$(XINPUT_LIBS)		\
 	$(NULL)
 
 plugin_in_files = 		\

--- a/plugins/xrandr/Makefile.am
+++ b/plugins/xrandr/Makefile.am
@@ -70,7 +70,9 @@ libxrandr_la_LDFLAGS = 			\
 libxrandr_la_LIBADD  =			\
 	$(SETTINGS_PLUGIN_LIBS)		\
 	$(LIBNOTIFY_LIBS)		\
-	$(MATE_DESKTOP_LIBS)
+	$(MATE_DESKTOP_LIBS)		\
+	$(X11_LIBS)			\
+	$(NULL)
 
 plugin_in_files =			\
 	xrandr.mate-settings-plugin.desktop.in

--- a/plugins/xsettings/Makefile.am
+++ b/plugins/xsettings/Makefile.am
@@ -38,6 +38,7 @@ libxsettings_la_LDFLAGS = 	\
 libxsettings_la_LIBADD  = 	\
 	$(SETTINGS_PLUGIN_LIBS)	\
 	$(FONTCONFIG_LIBS)	\
+	$(X11_LIBS)		\
 	$(NULL)
 
 plugin_in_files = 		\


### PR DESCRIPTION
Many of the plugins have undefined references, but with GNU libtool it silently ignores the `-no-undefined` flag so the build succeeds. With slibtool it correctly sets `-Wl,--no-undefined` in the linker flags causing the build to fail.

Please view the commit messages for more details. The alternative to removing `-no-undefined` in the last commit is to turn most of `mate-settings-daemon` into a convenience library and link that into most of the plugins, but that doesn't seem correct.

This was reported for Gentoo: https://bugs.gentoo.org/922326