### PR TITLE
add a keyboard shortcut to start a screen reader

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
+++ b/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
@@ -156,7 +156,7 @@
       <description>Binding to show the screen magnifier</description>
     </key>
     <key name="screenreader" type="s">
-      <default>''</default>
+      <default>'&lt;Alt&gt;&lt;Mod4&gt;s'</default>
       <summary>Toggle screen reader</summary>
       <description>Binding to start the screen reader</description>
     </key>


### PR DESCRIPTION
The keybinding is alt+super+s.

This is my first contribution here, I am not sure how to verify my changes. Help appreciated.