### PR TITLE
Remove remaining unused references to dbus-glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,6 @@ dnl ---------------------------------------------------------------------------
 dnl - Dependencies
 dnl ---------------------------------------------------------------------------
 
-DBUS_GLIB_REQUIRED_VERSION=0.74
 GLIB_REQUIRED_VERSION=2.58.0
 GIO_REQUIRED_VERSION=2.50.0
 GTK_REQUIRED_VERSION=3.22.0

--- a/data/mate-settings-daemon-uninstalled.pc.in
+++ b/data/mate-settings-daemon-uninstalled.pc.in
@@ -6,7 +6,7 @@ binary=${pc_top_builddir}/mate-settings-daemon/mate-settings-daemon
 
 Name: mate-settings-daemon
 Description: Utility library for accessing mate-settings-daemon over DBUS
-Requires: glib-2.0 dbus-1 dbus-glib-1
+Requires: glib-2.0 dbus-1
 Version: @VERSION@
 Libs: ${pc_top_builddir}/${pcfiledir}/libmate-settings-daemon.la
 Cflags: -I${pc_top_builddir}/${pcfiledir}/..

--- a/data/mate-settings-daemon.pc.in
+++ b/data/mate-settings-daemon.pc.in
@@ -8,7 +8,7 @@ binary=${libexecdir}/mate-settings-daemon
 
 Name: mate-settings-daemon
 Description: Utility library for accessing mate-settings-daemon over DBUS
-Requires: glib-2.0 dbus-1 dbus-glib-1
+Requires: glib-2.0 dbus-1
 Version: @VERSION@
 Libs: -L${libdir}
 Cflags: -I${includedir}/mate-settings-daemon


### PR DESCRIPTION
We already switched the code over to using gdbus during the 1.27 development cycle. This removes three remnants