### PR TITLE
xsettings: Add gsettings for custom XSettings overrides

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.xsettings.gschema.xml.in
+++ b/data/org.mate.SettingsDaemon.plugins.xsettings.gschema.xml.in
@@ -10,5 +10,10 @@
       <summary>Priority to use for this plugin</summary>
       <description>Priority to use for this plugin in mate-settings-daemon startup queue</description>
     </key>
+    <key type="a{sv}" name="overrides">
+      <default>{}</default>
+      <summary>A dictionary of XSETTINGS to override</summary>
+      <description>This dictionary maps XSETTINGS names to overrides values. The values must be either strings, signed int32s or (in the case of colors), 4-tuples of uint16 (red, green, blue, alpha; 65535 is fully opaque).</description>
+    </key>
   </schema>
 </schemalist>

--- a/plugins/xsettings/xsettings-manager.h
+++ b/plugins/xsettings/xsettings-manager.h
@@ -25,6 +25,7 @@
 #define XSETTINGS_MANAGER_H
 
 #include <X11/Xlib.h>
+#include <glib.h>
 #include "xsettings-common.h"
 
 #ifdef __cplusplus
@@ -62,6 +63,8 @@ XSettingsResult xsettings_manager_set_color      (XSettingsManager       *manage
                                                   const char             *name,
                                                   const XSettingsColor   *value);
 XSettingsResult xsettings_manager_notify         (XSettingsManager *manager);
+void            xsettings_manager_set_overrides  (XSettingsManager *manager,
+                                                  GVariant         *overrides);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add XSettings override gsettings to allow changing arbitrary XSettings on GSettings without requiring code changes. This enables third-party tools (like unity-gtk-module extensions) to integrate with MATE by setting custom XSettings values at runtime.

The implementation adds an 'overrides' key to the xsettings plugin schema which accepts a dictionary mapping XSetting names to values.

The complete list of XSettings is over at
https://www.freedesktop.org/wiki/Specifications/XSettingsRegistry/

Backported mostly from:
- https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/c6e9079d
- https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/35764838

Fixes: https://github.com/mate-desktop/mate-settings-daemon/issues/158

This is a really old feature I've been wanting to backport to fix some longstanding HiDPI quirks (which I hope to have time for soon). To test this, you can try something like
```
$ gsettings set org.mate.SettingsDaemon.plugins.xsettings overrides "{'Gtk/FontName': <'Sans 16'>}"
```